### PR TITLE
add the HttpAction event to the ICnpOnline interface

### DIFF
--- a/CnpSdkForNet/CnpSdkForNet/CnpOnline.cs
+++ b/CnpSdkForNet/CnpSdkForNet/CnpOnline.cs
@@ -873,5 +873,6 @@ namespace Cnp.Sdk
         Task<giftCardCreditResponse> GiftCardCreditAsync(giftCardCredit giftCardCredit, CancellationToken cancellationToken);
         transactionTypeWithReportGroup QueryTransaction(queryTransaction queryTransaction);
         Task<transactionTypeWithReportGroup> QueryTransactionAsync(queryTransaction queryTransaction, CancellationToken cancellationToken);
+        event EventHandler HttpAction;
     }
 }


### PR DESCRIPTION
The HTTPAction event is directly on the CnpOnline class, not the ICnpOnline interface so programming to the interface is difficult. This adds it to the interface for easier mocking.