### PR TITLE
Optionally control the console output of API responses

### DIFF
--- a/CnpSdkForNet/CnpSdkForNet/CnpOnline.cs
+++ b/CnpSdkForNet/CnpSdkForNet/CnpOnline.cs
@@ -712,7 +712,8 @@ namespace Cnp.Sdk
             try
             {
                 var cnpOnlineResponse = DeserializeObject(xmlResponse);
-                Console.WriteLine(cnpOnlineResponse.response);
+                if (!_config.ContainsKey("logResponse") || "1".Equals(_config["logResponse"]))
+                    Console.WriteLine(cnpOnlineResponse.response);
                 if (!"0".Equals(cnpOnlineResponse.response))
                 {
                     if ("2".Equals(cnpOnlineResponse.response) || "3".Equals(cnpOnlineResponse.response))


### PR DESCRIPTION
Allows a configuration setting to control whether the API response code is dumped to the console.