### PR TITLE
Probably shouldn't clobber existing settings.

### DIFF
--- a/CnpSdkForNet/CnpSdkForNet/Communications.cs
+++ b/CnpSdkForNet/CnpSdkForNet/Communications.cs
@@ -100,7 +100,7 @@ namespace Cnp.Sdk
 
             RequestTarget reqTarget = CommManager.instance().findUrl();
             var uri = reqTarget.getUrl();
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 ;
+            ServicePointManager.SecurityProtocol = ServicePointManager.SecurityProtocol | SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11;
             var request = (HttpWebRequest)WebRequest.Create(uri);
 
             var neuter = false;
@@ -208,7 +208,7 @@ namespace Cnp.Sdk
 
             RequestTarget reqTarget = CommManager.instance(config).findUrl();
             var uri = reqTarget.getUrl();
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11;
+            ServicePointManager.SecurityProtocol = ServicePointManager.SecurityProtocol | SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11;
             var req = (HttpWebRequest)WebRequest.Create(uri);
 
             var neuter = false;


### PR DESCRIPTION
While TLS 1.1 and 1.2 are required to access the Vantiv / cnp api, this SDK should not clobber the existing settings of the application using the SDK. Instead, just expand their settings if necessary.

This can be a problem in scenarios where my application `A` uses the SDK to communicate with cnp, but my application also needs to access my other application `B`. Application `B` has Its settings set to something different (e.g. SSL3/Tls). After using the SDK, `A` should still be able to communicate with `B`.