### PR TITLE
Change checkoutIdType field in cardTokenType to checkoutId

### DIFF
--- a/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
+++ b/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
@@ -3350,14 +3350,14 @@ namespace Cnp.Sdk
             set { typeField = value; typeSet = true; }
         }
 
-        private string checkoutIdTypeField;
-        private bool checkoutIdTypeSet;
+        private string checkoutIdField;
+        private bool checkoutIdSet;
 
-        public string checkoutIdType
+        public string checkoutId
         {
-            get { return checkoutIdTypeField; }
-            set { checkoutIdTypeField = value;
-                checkoutIdTypeSet = true;
+            get { return checkoutIdField; }
+            set { checkoutIdField = value;
+                checkoutIdSet = true;
             }
         }    
 
@@ -3367,7 +3367,7 @@ namespace Cnp.Sdk
             if (expDate != null) xml += "\r\n<expDate>" + SecurityElement.Escape(expDate) + "</expDate>";
             if (cardValidationNum != null) xml += "\r\n<cardValidationNum>" + SecurityElement.Escape(cardValidationNum) + "</cardValidationNum>";
             if (typeSet) xml += "\r\n<type>" + methodOfPaymentSerializer.Serialize(typeField) + "</type>";
-            if (checkoutIdTypeSet) xml += "\r\n<checkoutId>" + checkoutIdType + "</checkoutId>";
+            if (checkoutIdSet) xml += "\r\n<checkoutId>" + checkoutId + "</checkoutId>";
             return xml;
         }
     }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestSubscriptionTxns.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestSubscriptionTxns.cs
@@ -80,7 +80,7 @@ namespace Cnp.Sdk.Test.Functional
                     expDate = "0750",
                     cardValidationNum = "798",
                     type = methodOfPaymentTypeEnum.VI,
-                    checkoutIdType = "012345678901234567"
+                    checkoutId = "012345678901234567"
                 },
                 planCode = "abcdefg",
                 subscriptionId = 12345

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestUpdateSubscription.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestUpdateSubscription.cs
@@ -76,7 +76,7 @@ namespace Cnp.Sdk.Test.Unit
                     expDate = "0750",
                     cardValidationNum = "798",
                     type = methodOfPaymentTypeEnum.VI,
-                    checkoutIdType = "0123456789012345678"
+                    checkoutId = "0123456789012345678"
                 },
                 planCode = "abcdefg",
                 subscriptionId = 12345


### PR DESCRIPTION
Rename checkoutIdType field to checkoutId to align our eProtect solution with SDK.