### PR TITLE
Use the same content type in HttpPost and HttpPostCoreAsync.

### DIFF
--- a/CnpSdkForNet/CnpSdkForNet/Communications.cs
+++ b/CnpSdkForNet/CnpSdkForNet/Communications.cs
@@ -274,7 +274,7 @@ namespace Cnp.Sdk
                 Log(xmlRequest, logFile, neuterAccNums, neuterCreds);
             }
 
-            req.ContentType = "text/xml";
+            req.ContentType = ContentTypeTextXmlUTF8;
             req.Method = "POST";
             req.ServicePoint.MaxIdleTime = 8000;
             req.ServicePoint.Expect100Continue = false;


### PR DESCRIPTION
When we switched from async to sync (so that we could use NewRelic to trace these requests), we started getting requests rejected with:
```
Cnp.Sdk.CnpOnlineException: Error validating xml data against the schema on line 13
the length of the value is 41, but the required maximum is 35.
```
This happened when users in other countries had UTF-8 characters in their address.

Let me know if you need any more information for this change.