### PR TITLE
Update SDK to v12.11

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 
 = Worldpay CNP CHANGELOG
 
+==Version 12.11.0 (February 12, 2020)
+* Feature: Added MCC (merchantCategoryCode) in request
+* Feature: Added authenticationProtocolVersionType in request
+
 ==Version 12.10.3 (December 16, 2019)
 * Changed: Removed Multisite support at SDK-level in favor Global Load Balancer (GLB)
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 
 = Worldpay CNP CHANGELOG
 
-==Version 12.11.0 (February 12, 2020)
+==Version 12.11.0 (February 17, 2020)
 * Feature: Added MCC (merchantCategoryCode) in request
 * Feature: Added authenticationProtocolVersionType in request
 

--- a/CnpSdkForNet/CnpSdkForNet/CnpSdkForNet.csproj
+++ b/CnpSdkForNet/CnpSdkForNet/CnpSdkForNet.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>dotNetSDKKey.snk</AssemblyOriginatorKeyFile>
-        <PackageVersion>12.10.3</PackageVersion>
+        <PackageVersion>12.11.0</PackageVersion>
         <Title>Vantiv.CnpSdkForNet</Title>
         <Authors>Worldpay</Authors>
         <Copyright>Copyright © Worldpay 2019</Copyright>

--- a/CnpSdkForNet/CnpSdkForNet/CnpVersion.cs
+++ b/CnpSdkForNet/CnpSdkForNet/CnpVersion.cs
@@ -8,7 +8,7 @@ namespace Cnp.Sdk
      */
     public class CnpVersion
     {
-        public const String CurrentCNPXMLVersion = "12.10";
-        public const String CurrentCNPSDKVersion = "12.10.3";
+        public const String CurrentCNPXMLVersion = "12.11";
+        public const String CurrentCNPSDKVersion = "12.11";
     }
 }

--- a/CnpSdkForNet/CnpSdkForNet/CnpVersion.cs
+++ b/CnpSdkForNet/CnpSdkForNet/CnpVersion.cs
@@ -9,6 +9,6 @@ namespace Cnp.Sdk
     public class CnpVersion
     {
         public const String CurrentCNPXMLVersion = "12.11";
-        public const String CurrentCNPSDKVersion = "12.11";
+        public const String CurrentCNPSDKVersion = "12.11.0";
     }
 }

--- a/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
+++ b/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
@@ -386,6 +386,8 @@ namespace Cnp.Sdk
         }
         public bool? skipRealtimeAU;
 
+        public string merchantCategoryCode;
+
         public override string Serialize()
         {
             var xml = "\r\n<authorization";
@@ -527,6 +529,11 @@ namespace Cnp.Sdk
                 }
                 if (skipRealtimeAU != null) {
                     xml += "\r\n<skipRealtimeAU>" + skipRealtimeAU.ToString().ToLower() + "</skipRealtimeAU>";
+                }
+
+                if (merchantCategoryCode != null)
+                {
+                    xml += "\r\n<merchantCategoryCode>" + merchantCategoryCode + "</merchantCategoryCode>";
                 }
             }
 
@@ -793,6 +800,8 @@ namespace Cnp.Sdk
             }
         }
 
+        public string merchantCategoryCode;
+
         public override string Serialize()
         {
             var xml = "\r\n<captureGivenAuth";
@@ -883,6 +892,10 @@ namespace Cnp.Sdk
             if (originalTransactionAmountSet)
             {
                 xml += "\r\n<originalTransactionAmount>" + originalTransactionAmount + "</originalTransactionAmount>";
+            }
+            if (merchantCategoryCode != null)
+            {
+                xml += "\r\n<merchantCategoryCode>" + merchantCategoryCode + "</merchantCategoryCode>";
             }
             xml += "\r\n</captureGivenAuth>";
             return xml;
@@ -1016,6 +1029,7 @@ namespace Cnp.Sdk
         }
         public amexAggregatorData amexAggregatorData;
         public merchantDataType merchantData;
+        public string merchantCategoryCode;
         public string payPalNotes;
         public string actionReason;
 
@@ -1071,6 +1085,10 @@ namespace Cnp.Sdk
                 if (pos != null) xml += "\r\n<pos>" + pos.Serialize() + "</pos>";
                 if (amexAggregatorData != null) xml += "\r\n<amexAggregatorData>" + amexAggregatorData.Serialize() + "</amexAggregatorData>";
                 if (merchantData != null) xml += "\r\n<merchantData>" + merchantData.Serialize() + "</merchantData>";
+                if (merchantCategoryCode != null)
+                {
+                    xml += "\r\n<merchantCategoryCode>" + merchantCategoryCode + "</merchantCategoryCode>";
+                }
             }
             if (payPalNotes != null) xml += "\r\n<payPalNotes>" + SecurityElement.Escape(payPalNotes) + "</payPalNotes>";
             if (actionReason != null) xml += "\r\n<actionReason>" + SecurityElement.Escape(actionReason) + "</actionReason>";
@@ -1509,6 +1527,8 @@ namespace Cnp.Sdk
             set { processingTypeField = value; processingTypeSet = true; }
         }
 
+        public string merchantCategoryCode;
+
         public override string Serialize()
         {
             var xml = "\r\n<forceCapture";
@@ -1583,6 +1603,12 @@ namespace Cnp.Sdk
             {
                 xml += "\r\n<processingType>" + processingType + "</processingType>";
             }
+
+            if (merchantCategoryCode != null)
+            {
+                xml += "\r\n<merchantCategoryCode>" + merchantCategoryCode + "</merchantCategoryCode>";
+            }
+            
             xml += "\r\n</forceCapture>";
             return xml;
         }
@@ -1594,6 +1620,7 @@ namespace Cnp.Sdk
         public string authenticationValue;
         public string authenticationTransactionId;
         public string customerIpAddress;
+        public string authenticationProtocolVersionType;
         private bool authenticatedByMerchantField;
         private bool authenticatedByMerchantSet;
         public bool authenticatedByMerchant
@@ -1609,6 +1636,7 @@ namespace Cnp.Sdk
             if (authenticationTransactionId != null) xml += "\r\n<authenticationTransactionId>" + SecurityElement.Escape(authenticationTransactionId) + "</authenticationTransactionId>";
             if (customerIpAddress != null) xml += "\r\n<customerIpAddress>" + SecurityElement.Escape(customerIpAddress) + "</customerIpAddress>";
             if (authenticatedByMerchantSet) xml += "\r\n<authenticatedByMerchant>" + authenticatedByMerchantField + "</authenticatedByMerchant>";
+            if(authenticationProtocolVersionType != null) xml += "\r\n<authenticationProtocolVersionType>" + authenticationProtocolVersionType + "</authenticationProtocolVersionType>";
             return xml;
         }
     }
@@ -2121,6 +2149,7 @@ namespace Cnp.Sdk
 
         public pinlessDebitRequestType pinlessDebitRequest;
         public bool? skipRealtimeAU;
+        public string merchantCategoryCode;
 
         //private routingPreferenceEnum routingPreferenceField;
         //private bool routingPreferenceSet;
@@ -2292,6 +2321,10 @@ namespace Cnp.Sdk
             }
             if (skipRealtimeAU != null) {
                 xml += "\r\n<skipRealtimeAU>" + skipRealtimeAU.ToString().ToLower() + "</skipRealtimeAU>";
+            }
+            if (merchantCategoryCode != null)
+            {
+                xml += "\r\n<merchantCategoryCode>" + merchantCategoryCode + "</merchantCategoryCode>";
             }
 
             //if (routingPreferenceSet)

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestCustomer.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestCustomer.cs
@@ -22,7 +22,7 @@ namespace Cnp.Sdk.Test.Functional {
                 fundingCustomerId = "value for fundingCustomerId",
                 customerName = "value for customerName",
                 fundsTransferId = "value for fundsTransferId",
-                amount = 500,
+                amount = 1512l,
                 customIdentifier = "WorldPay",
                 accountInfo = new echeckType() {
                     accType = echeckAccountTypeEnum.Checking,
@@ -45,7 +45,7 @@ namespace Cnp.Sdk.Test.Functional {
                 fundingCustomerId = "value for fundingCustomerId",
                 customerName = "value for customerName",
                 fundsTransferId = "value for fundsTransferId",
-                amount = 500,
+                amount = 1512l,
                 customIdentifier = "WorldPay",
                 accountInfo = new echeckType() {
                     accType = echeckAccountTypeEnum.Checking,
@@ -68,7 +68,7 @@ namespace Cnp.Sdk.Test.Functional {
 
                 fundingCustomerId = "value for fundingCustomerId",
                 fundsTransferId = "value for fundsTransferId",
-                amount = 500,
+                amount = 1512l,
                 customIdentifier = "WorldPay",
                 accountInfo = new echeckType() {
                     accType = echeckAccountTypeEnum.Checking,
@@ -89,7 +89,7 @@ namespace Cnp.Sdk.Test.Functional {
 
                 fundingCustomerId = "value for fundingCustomerId",
                 fundsTransferId = "value for fundsTransferId",
-                amount = 500,
+                amount = 1512l,
                 customIdentifier = "WorldPay",
                 accountInfo = new echeckType() {
                     accType = echeckAccountTypeEnum.Checking,
@@ -112,7 +112,7 @@ namespace Cnp.Sdk.Test.Functional {
                 fundingCustomerId = "value for fundingCustomerId",
                 customerName = "value for customerName",
                 fundsTransferId = "value for fundsTransferId",
-                amount = 500,
+                amount = 1512l,
                 customIdentifier = "WorldPay",
                 accountInfo = new echeckType() {
                     accType = echeckAccountTypeEnum.Checking,
@@ -135,7 +135,7 @@ namespace Cnp.Sdk.Test.Functional {
                 fundingCustomerId = "value for fundingCustomerId",
                 customerName = "value for customerName",
                 fundsTransferId = "value for fundsTransferId",
-                amount = 500,
+                amount = 1512l,
                 customIdentifier = "WorldPay",
                 accountInfo = new echeckType() {
                     accType = echeckAccountTypeEnum.Checking,
@@ -158,7 +158,7 @@ namespace Cnp.Sdk.Test.Functional {
 
                 fundingCustomerId = "value for fundingCustomerId",
                 fundsTransferId = "value for fundsTransferId",
-                amount = 500,
+                amount = 1512l,
                 customIdentifier = "WorldPay",
                 accountInfo = new echeckType() {
                     accType = echeckAccountTypeEnum.Checking,
@@ -179,7 +179,7 @@ namespace Cnp.Sdk.Test.Functional {
 
                 fundingCustomerId = "value for fundingCustomerId",
                 fundsTransferId = "value for fundsTransferId",
-                amount = 500,
+                amount = 1512l,
                 customIdentifier = "WorldPay",
                 accountInfo = new echeckType() {
                     accType = echeckAccountTypeEnum.Checking,
@@ -203,7 +203,7 @@ namespace Cnp.Sdk.Test.Functional {
                 fundingCustomerId = "value for fundingCustomerId",
                 customerName = "value for customerName",
                 fundsTransferId = "value for fundsTransferId",
-                amount = -500,
+                amount = -1512l,
                 customIdentifier = "WorldPay",
                 accountInfo = new echeckType() {
                     accType = echeckAccountTypeEnum.Checking,
@@ -226,7 +226,7 @@ namespace Cnp.Sdk.Test.Functional {
                 fundingCustomerId = "123456789012345678901234567890123456789012345678901234567890",
                 customerName = "value for customerName",
                 fundsTransferId = "value for fundsTransferId",
-                amount = 500,
+                amount = 1512l,
                 customIdentifier = "WorldPay",
                 accountInfo = new echeckType() {
                     accType = echeckAccountTypeEnum.Checking,
@@ -248,7 +248,7 @@ namespace Cnp.Sdk.Test.Functional {
                 fundingCustomerId = "123456789012345678901234567890123456789012345678901234567890",
                 customerName = "value for customerName",
                 fundsTransferId = "value for fundsTransferId",
-                amount = 500,
+                amount = 1512l,
                 customIdentifier = "WorldPay",
                 accountInfo = new echeckType() {
                     accType = echeckAccountTypeEnum.Checking,

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestForceCapture.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestForceCapture.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 using System.Threading;
 
@@ -30,8 +31,10 @@ namespace Cnp.Sdk.Test.Functional
                     type = methodOfPaymentTypeEnum.VI,
                     number = "4100000000000001",
                     expDate = "1210"
-                }
+                },
+                merchantCategoryCode = "1111"
             };
+            
 
             var response = _cnp.ForceCapture(forcecapture);
             Assert.AreEqual("Approved", response.message);

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestPayFac.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestPayFac.cs
@@ -24,7 +24,7 @@ namespace Cnp.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Default Report Group",
                 // required child elements.
-                amount = 1500,
+                amount = 1512l,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId"
             };
@@ -42,7 +42,7 @@ namespace Cnp.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Default Report Group",
                 // required child elements.
-                amount = 1500,
+                amount = 1512l,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId"
             };
@@ -61,7 +61,7 @@ namespace Cnp.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Planets",
                 // required child elements.
-                amount = 1500,
+                amount = 1512l,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId"
             };
@@ -79,7 +79,7 @@ namespace Cnp.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Planets",
                 // required child elements.
-                amount = 1500,
+                amount = 1512l,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId"
             };

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestPayoutOrg.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestPayoutOrg.cs
@@ -22,7 +22,7 @@ namespace Cnp.Sdk.Test.Functional {
             {
                 id = "1",
                 reportGroup = "Default Report Group",
-                amount = 1500,
+                amount = 1512l,
                 fundingCustomerId = "value for fundingCustomerId",
                 fundsTransferId = "value for fundsTransferId",
             };
@@ -38,7 +38,7 @@ namespace Cnp.Sdk.Test.Functional {
             {
                 id = "1",
                 reportGroup = "Default Report Group",
-                amount = 1500,
+                amount = 1512l,
                 fundingCustomerId = "value for fundingCustomerId",
                 fundsTransferId = "value for fundsTransferId",
             };
@@ -85,7 +85,7 @@ namespace Cnp.Sdk.Test.Functional {
             {
                 id = "1",
                 reportGroup = "Default Report Group",
-                amount = 1500,
+                amount = 1512l,
                 fundingCustomerId = "value for fundingCustomerId",
                 fundsTransferId = "value for fundsTransferId",
             };
@@ -101,7 +101,7 @@ namespace Cnp.Sdk.Test.Functional {
             {
                 id = "1",
                 reportGroup = "Default Report Group",
-                amount = 1500,
+                amount = 1512l,
                 fundingCustomerId = "value for fundingCustomerId",
                 fundsTransferId = "value for fundsTransferId",
             };

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestPhysicalCheck.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestPhysicalCheck.cs
@@ -24,7 +24,7 @@ namespace Cnp.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Default Report Group",
                 // required child elements.
-                amount = 1500,
+                amount = 1512l,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId"
             };
@@ -42,7 +42,7 @@ namespace Cnp.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Default Report Group",
                 // required child elements.
-                amount = 1500,
+                amount = 1512l,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId",
                 fundingCustomerId = "value for fundingCustomerId",
@@ -61,7 +61,7 @@ namespace Cnp.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Default Report Group",
                 // required child elements.
-                amount = 1500,
+                amount = 1512l,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId"
             };
@@ -80,7 +80,7 @@ namespace Cnp.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Planets",
                 // required child elements.
-                amount = 1500,
+                amount = 1512l,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId"
             };
@@ -98,7 +98,7 @@ namespace Cnp.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Planets",
                 // required child elements.
-                amount = 1500,
+                amount = 1512l,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId",
                 fundingCustomerId = "value for fundingCustomerId",
@@ -117,7 +117,7 @@ namespace Cnp.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Planets",
                 // required child elements.
-                amount = 1500,
+                amount = 1512l,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId"
             };

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestReserve.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestReserve.cs
@@ -24,7 +24,7 @@ namespace Cnp.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Default Report Group",
                 // required child elements.
-                amount = 1500,
+                amount = 1512l,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId"
             };
@@ -42,7 +42,7 @@ namespace Cnp.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Default Report Group",
                 // required child elements.
-                amount = 1500,
+                amount = 1512l,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId"
             };
@@ -61,7 +61,7 @@ namespace Cnp.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Default Report Group",
                 // required child elements.
-                amount = 1500,
+                amount = 1512l,
                 fundingCustomerId = "value for fundingCustomerId",
                 fundsTransferId = "value for fundsTransferId"
             };
@@ -79,7 +79,7 @@ namespace Cnp.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Planets",
                 // required child elements.
-                amount = 1500,
+                amount = 1512l,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId"
             };
@@ -97,7 +97,7 @@ namespace Cnp.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Planets",
                 // required child elements.
-                amount = 1500,
+                amount = 1512l,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId"
             };
@@ -116,7 +116,7 @@ namespace Cnp.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Default Report Group",
                 // required child elements.
-                amount = 1500,
+                amount = 1512l,
                 fundingCustomerId = "value for fundingCustomerId",
                 fundsTransferId = "value for fundsTransferId"
             };
@@ -134,7 +134,7 @@ namespace Cnp.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Default Report Group",
                 // required child elements.
-                amount = 1500,
+                amount = 1512l,
                 fundingCustomerId = "value <for> fundingCustomerId",
                 fundsTransferId = "value for fundsTransferId"
             };

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestSubmerchant.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestSubmerchant.cs
@@ -30,7 +30,7 @@ namespace Cnp.Sdk.Test.Functional
                     accNum = "1234",
                     routingNum = "12345678"
                 },
-                amount = 1500,
+                amount = 1512l,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId",
                 submerchantName = "Vantiv",
@@ -56,7 +56,7 @@ namespace Cnp.Sdk.Test.Functional
                     accNum = "1234",
                     routingNum = "12345678"
                 },
-                amount = 1500,
+                amount = 1512l,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId",
                 submerchantName = "Vantiv",
@@ -83,7 +83,7 @@ namespace Cnp.Sdk.Test.Functional
                     accNum = "1234",
                     routingNum = "12345678"
                 },
-                amount = 1500,
+                amount = 1512l,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId",
                 submerchantName = "Vantiv",
@@ -109,7 +109,7 @@ namespace Cnp.Sdk.Test.Functional
                     accNum = "1234",
                     routingNum = "12345678"
                 },
-                amount = 1500,
+                amount = 1512l,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId",
                 submerchantName = "Vantiv",

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestVendor.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestVendor.cs
@@ -30,7 +30,7 @@ namespace Cnp.Sdk.Test.Functional
                     accNum = "1234",
                     routingNum = "12345678"
                 },
-                amount = 1500,
+                amount = 1512l,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId",
                 vendorName = "Vantiv"
@@ -55,7 +55,7 @@ namespace Cnp.Sdk.Test.Functional
                     accNum = "1234",
                     routingNum = "12345678"
                 },
-                amount = 1500,
+                amount = 1512l,
                 fundingCustomerId = "value for fundingCustomerId",
                 fundsTransferId = "value for fundsTransferId",
                 vendorName = "Vantiv"
@@ -80,7 +80,7 @@ namespace Cnp.Sdk.Test.Functional
                     accNum = "1234",
                     routingNum = "12345678"
                 },
-                amount = 1500,
+                amount = 1512l,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId",
                 vendorName = "Vantiv"
@@ -106,7 +106,7 @@ namespace Cnp.Sdk.Test.Functional
                     accNum = "1234",
                     routingNum = "12345678"
                 },
-                amount = 1500,
+                amount = 1512l,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId",
                 vendorName = "WorldPay"
@@ -131,7 +131,7 @@ namespace Cnp.Sdk.Test.Functional
                     accNum = "1234",
                     routingNum = "12345678"
                 },
-                amount = 1500,
+                amount = 1512l,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId",
                 fundingCustomerId = "value for fundingCustomerId",
@@ -157,7 +157,7 @@ namespace Cnp.Sdk.Test.Functional
                     accNum = "1234",
                     routingNum = "12345678"
                 },
-                amount = 1500,
+                amount = 1512l,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId",
                 vendorName = "WorldPay"

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestAuthorization.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestAuthorization.cs
@@ -347,7 +347,9 @@ namespace Cnp.Sdk.Test.Unit
             auth.orderId = "12344";
             auth.amount = 2;
             auth.orderSource = orderSourceType.ecommerce;
-            auth.cardholderAuthentication = new fraudCheckType();
+            fraudCheckType checkType = new fraudCheckType();
+            checkType.authenticationProtocolVersionType = "PAP";
+            auth.cardholderAuthentication = checkType;
             auth.cardholderAuthentication.customerIpAddress = "192.168.1.1";
 
             var expectedResult = @"
@@ -362,13 +364,14 @@ namespace Cnp.Sdk.Test.Unit
 </card>
 <cardholderAuthentication>
 <customerIpAddress>192.168.1.1</customerIpAddress>
+<authenticationProtocolVersionType>PAP</authenticationProtocolVersionType>
 </cardholderAuthentication>
 </authorization>";
 
             Assert.AreEqual(Regex.Replace(expectedResult, @"\s+", string.Empty), Regex.Replace(auth.Serialize(), @"\s+", string.Empty));
 
             var mock = new Mock<Communications>();
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<authorization id=\".*>.*<customerIpAddress>192.168.1.1</customerIpAddress>.*</authorization>.*", RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<authorization id=\".*>.*<customerIpAddress>192.168.1.1</customerIpAddress>.*<authenticationProtocolVersionType>PAP</authenticationProtocolVersionType>.*</authorization>.*", RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
                 .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><authorizationResponse><cnpTxnId>123</cnpTxnId></authorizationResponse></cnpOnlineResponse>");
 
             var mockedCommunication = mock.Object;

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestAuthorization.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestAuthorization.cs
@@ -610,5 +610,28 @@ namespace Cnp.Sdk.Test.Unit
             var authorizationResponse = cnp.Authorize(auth);
             Assert.AreEqual(123, authorizationResponse.cnpTxnId);
         }
+
+        [Test]
+        public void TestAuthWithMCC()
+        {
+            var auth = new authorization();
+            auth.orderId = "12344";
+            auth.amount = 2;
+            auth.merchantCategoryCode = "0111";
+            auth.orderSource = orderSourceType.ecommerce;
+            auth.reportGroup = "Planets";
+
+            var mock = new Mock<Communications>();
+
+            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<orderSource>ecommerce</orderSource>\r\n<merchantCategoryCode>0111</merchantCategoryCode>.*", RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><authorizationResponse><cnpTxnId>123</cnpTxnId></authorizationResponse></cnpOnlineResponse>");
+
+            var mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            var authorizationResponse = cnp.Authorize(auth);
+
+            Assert.NotNull(authorizationResponse);
+            Assert.AreEqual(123, authorizationResponse.cnpTxnId);
+        }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestCaptureGivenAuth.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestCaptureGivenAuth.cs
@@ -165,5 +165,24 @@ namespace Cnp.Sdk.Test.Unit
             cnp.SetCommunication(mockedCommunication);
             cnp.CaptureGivenAuth(capture);
         }
+
+        [Test]
+        public void TestCaptureAuthWithMCC()
+        {
+            captureGivenAuth capture = new captureGivenAuth();
+            capture.amount = 2;
+            capture.merchantCategoryCode = "0111";
+            capture.orderSource = orderSourceType.ecommerce;
+            capture.reportGroup = "Planets";
+
+            var mock = new Mock<Communications>();
+
+            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<orderSource>ecommerce</orderSource>\r\n<merchantCategoryCode>0111</merchantCategoryCode>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
+                .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><captureGivenAuthResponse><cnpTxnId>123</cnpTxnId></captureGivenAuthResponse></cnpOnlineResponse>");
+
+            Communications mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            cnp.CaptureGivenAuth(capture);
+        }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestCredit.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestCredit.cs
@@ -242,6 +242,26 @@ namespace Cnp.Sdk.Test.Unit
             cnp.Credit(credit);
         }
 
+        [Test]
+        public void TestCreditWithMCC()
+        {
+            credit credit = new credit();
+            credit.amount = 2;
+            credit.merchantCategoryCode = "0111";
+            credit.orderId = "3";
+            credit.orderSource = orderSourceType.ecommerce;
+            credit.reportGroup = "Planets";
+
+            var mock = new Mock<Communications>();
+
+            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<orderId>3</orderId>\r\n<amount>2</amount>\r\n<orderSource>ecommerce</orderSource>\r\n<merchantCategoryCode>0111</merchantCategoryCode>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
+                .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><creditResponse><cnpTxnId>123</cnpTxnId></creditResponse></cnpOnlineResponse>");
+
+            Communications mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            cnp.Credit(credit);
+        }
+
 
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestForceCapture.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestForceCapture.cs
@@ -165,5 +165,24 @@ namespace Cnp.Sdk.Test.Unit
             cnp.SetCommunication(mockedCommunication);
             cnp.ForceCapture(capture);
         }
+
+        [Test]
+        public void TestForceCaptureWithMCC()
+        {
+            forceCapture capture = new forceCapture();
+            capture.amount = 2;
+            capture.merchantCategoryCode = "0111";
+            capture.orderSource = orderSourceType.ecommerce;
+            capture.reportGroup = "Planets";
+
+            var mock = new Mock<Communications>();
+
+            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<orderSource>ecommerce</orderSource>\r\n<merchantCategoryCode>0111</merchantCategoryCode>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
+                .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><forceCaptureResponse><cnpTxnId>123</cnpTxnId></forceCaptureResponse></cnpOnlineResponse>");
+
+            Communications mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            cnp.ForceCapture(capture);
+        }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestSale.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestSale.cs
@@ -417,5 +417,24 @@ namespace Cnp.Sdk.Test.Unit
             cnp.SetCommunication(mockedCommunication);
             cnp.Sale(sale);
         }
+
+        [Test]
+        public void TestSaleWithMCC()
+        {
+            sale sale = new sale();
+            sale.amount = 2;
+            sale.merchantCategoryCode = "0111";
+            sale.orderSource = orderSourceType.ecommerce;
+            sale.reportGroup = "Planets";
+
+            var mock = new Mock<Communications>();
+
+            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<orderSource>ecommerce</orderSource>\r\n<merchantCategoryCode>0111</merchantCategoryCode>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
+                .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><saleResponse><cnpTxnId>123</cnpTxnId></saleResponse></cnpOnlineResponse>");
+
+            Communications mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            cnp.Sale(sale);
+        }
     }
 }


### PR DESCRIPTION
The goal of this change is to update the SDK to version 12.11. 

Changes from 12.10 to this version include the addition of a merchantCategoryCode element to forceCapture, captureGivenAuth, sale, credit and authorization for requests and the addition of an element authenticationProtocolVersionType to fraudCheckType.

Various fixes are also included for functional tests that were failing. 