### PR TITLE
Update SDK to v12.12

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 
 = Worldpay CNP CHANGELOG
 
-==Version 12.12.0 (February 18, 2020)
-* Feature: Added location element to cnpOnlineResponse
+==Version 12.12.0 (February 21, 2020)
+* Feature: Added location in responses for CnpOnline
 
 ==Version 12.11.0 (February 17, 2020)
 * Feature: Added MCC (merchantCategoryCode) in request

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 
 = Worldpay CNP CHANGELOG
 
+==Version 12.12.0 (February 18, 2020)
+* Feature: Added location element to cnpOnlineResponse
+
 ==Version 12.11.0 (February 17, 2020)
 * Feature: Added MCC (merchantCategoryCode) in request
 * Feature: Added authenticationProtocolVersionType in request

--- a/CnpSdkForNet/CnpSdkForNet/CnpOnline.cs
+++ b/CnpSdkForNet/CnpSdkForNet/CnpOnline.cs
@@ -343,12 +343,19 @@ namespace Cnp.Sdk
 
         public authorizationResponse Authorize(authorization auth)
         {
-            return SendRequest(response => response.authorizationResponse, auth);
+            var cnpResponse =  SendRequest(response => response, auth);
+            var authResponse = cnpResponse.authorizationResponse;
+            authResponse.location = cnpResponse.location;
+            return authResponse;
         }
 
         public authReversalResponse AuthReversal(authReversal reversal)
         {
-            return SendRequest(response => response.authReversalResponse, reversal);
+            
+            var cnpResponse =  SendRequest(response => response, reversal);
+            var reversalResponse = cnpResponse.authReversalResponse;
+            reversalResponse.location = cnpResponse.location;
+            return reversalResponse;
         }
 
         public Task<authReversalResponse> AuthReversalAsync(authReversal reversal, CancellationToken cancellationToken)
@@ -358,7 +365,10 @@ namespace Cnp.Sdk
 
         public giftCardAuthReversalResponse GiftCardAuthReversal(giftCardAuthReversal giftCard)
         {
-            return SendRequest(response => response.giftCardAuthReversalResponse, giftCard);
+            var cnpResponse =  SendRequest(response => response, giftCard);
+            var giftCardReversalResponse = cnpResponse.giftCardAuthReversalResponse;
+            giftCardReversalResponse.location = cnpResponse.location;
+            return giftCardReversalResponse;
         }
 
         public Task<giftCardAuthReversalResponse> GiftCardAuthReversalAsync(giftCardAuthReversal giftCard, CancellationToken cancellationToken)
@@ -373,12 +383,18 @@ namespace Cnp.Sdk
 
         public captureResponse Capture(capture capture)
         {
-            return SendRequest(response => response.captureResponse, capture);
+            var cnpResponse =  SendRequest(response => response, capture);
+            var captureResponse = cnpResponse.captureResponse;
+            captureResponse.location = cnpResponse.location;
+            return captureResponse;
         }
 
         public giftCardCaptureResponse GiftCardCapture(giftCardCapture giftCardCapture)
         {
-            return SendRequest(response => response.giftCardCaptureResponse, giftCardCapture);
+            var cnpResponse =  SendRequest(response => response, giftCardCapture);
+            var giftCaptureResponse = cnpResponse.giftCardCaptureResponse;
+            giftCaptureResponse.location = cnpResponse.location;
+            return giftCaptureResponse;
         }
 
         public Task<giftCardCaptureResponse> GiftCardCaptureAsync(giftCardCapture giftCardCapture, CancellationToken cancellationToken)
@@ -393,12 +409,18 @@ namespace Cnp.Sdk
 
         public captureGivenAuthResponse CaptureGivenAuth(captureGivenAuth captureGivenAuth)
         {
-            return SendRequest(response => response.captureGivenAuthResponse, captureGivenAuth);
+            var cnpResponse = SendRequest(response => response, captureGivenAuth);
+            var captureAuthResponse = cnpResponse.captureGivenAuthResponse;
+            captureAuthResponse.location = cnpResponse.location;
+            return captureAuthResponse;
         }
 
         public creditResponse Credit(credit credit)
         {
-            return SendRequest(response => response.creditResponse, credit);
+            var cnpResponse = SendRequest(response => response, credit);
+            var creditResponse = cnpResponse.creditResponse;
+            creditResponse.location = cnpResponse.location;
+            return creditResponse;
         }
 
         public Task<creditResponse> CreditAsync(credit credit, CancellationToken cancellationToken)
@@ -408,7 +430,10 @@ namespace Cnp.Sdk
 
         public giftCardCreditResponse GiftCardCredit(giftCardCredit giftCardCredit)
         {
-            return SendRequest(response => response.giftCardCreditResponse, giftCardCredit);
+            var cnpResponse = SendRequest(response => response, giftCardCredit);
+            var giftCreditResponse = cnpResponse.giftCardCreditResponse;
+            giftCreditResponse.location = cnpResponse.location;
+            return giftCreditResponse;
         }
 
         public Task<giftCardCreditResponse> GiftCardCreditAsync(giftCardCredit giftCardCredit, CancellationToken cancellationToken)
@@ -423,7 +448,10 @@ namespace Cnp.Sdk
 
         public echeckCreditResponse EcheckCredit(echeckCredit echeckCredit)
         {
-            return SendRequest(response => response.echeckCreditResponse, echeckCredit);
+            var cnpResponse = SendRequest(response => response, echeckCredit);
+            var eCheckCreditResponse = cnpResponse.echeckCreditResponse;
+            eCheckCreditResponse.location = cnpResponse.location;
+            return eCheckCreditResponse;
         }
 
         public Task<echeckRedepositResponse> EcheckRedepositAsync(echeckRedeposit echeckRedeposit, CancellationToken cancellationToken)
@@ -433,7 +461,10 @@ namespace Cnp.Sdk
 
         public echeckRedepositResponse EcheckRedeposit(echeckRedeposit echeckRedeposit)
         {
-            return SendRequest(response => response.echeckRedepositResponse, echeckRedeposit);
+            var cnpResponse = SendRequest(response => response, echeckRedeposit);
+            var eCheckRedepositResponse = cnpResponse.echeckRedepositResponse;
+            eCheckRedepositResponse.location = cnpResponse.location;
+            return eCheckRedepositResponse;
         }
 
         public Task<echeckSalesResponse> EcheckSaleAsync(echeckSale echeckSale, CancellationToken cancellationToken)
@@ -443,12 +474,18 @@ namespace Cnp.Sdk
 
         public echeckSalesResponse EcheckSale(echeckSale echeckSale)
         {
-            return SendRequest(response => response.echeckSalesResponse, echeckSale);
+            var cnpResponse = SendRequest(response => response, echeckSale);
+            var eCheckSaleResponse = cnpResponse.echeckSalesResponse;
+            eCheckSaleResponse.location = cnpResponse.location;
+            return eCheckSaleResponse;
         }
 
         public echeckVerificationResponse EcheckVerification(echeckVerification echeckVerification)
         {
-            return SendRequest(response => response.echeckVerificationResponse, echeckVerification);
+            var cnpResponse = SendRequest(response => response, echeckVerification);
+            var eCheckVerificationResponse = cnpResponse.echeckVerificationResponse;
+            eCheckVerificationResponse.location = cnpResponse.location;
+            return eCheckVerificationResponse;
         }
 
         public Task<echeckVerificationResponse> EcheckVerificationAsync(echeckVerification echeckVerification, CancellationToken cancellationToken)
@@ -458,7 +495,10 @@ namespace Cnp.Sdk
 
         public forceCaptureResponse ForceCapture(forceCapture forceCapture)
         {
-            return SendRequest(response => response.forceCaptureResponse, forceCapture);
+            var cnpResponse = SendRequest(response => response, forceCapture);
+            var forceCaptureResponse = cnpResponse.forceCaptureResponse;
+            forceCaptureResponse.location = cnpResponse.location;
+            return forceCaptureResponse;
         }
 
         public Task<forceCaptureResponse> ForceCaptureAsync(forceCapture forceCapture, CancellationToken cancellationToken)
@@ -468,7 +508,10 @@ namespace Cnp.Sdk
 
         public saleResponse Sale(sale sale)
         {
-            return SendRequest(response => response.saleResponse, sale);
+            var cnpResponse = SendRequest(response => response, sale);
+            var saleResponse = cnpResponse.saleResponse;
+            saleResponse.location = cnpResponse.location;
+            return saleResponse;
         }
 
         public Task<saleResponse> SaleAsync(sale sale, CancellationToken cancellationToken)
@@ -483,12 +526,18 @@ namespace Cnp.Sdk
 
         public registerTokenResponse RegisterToken(registerTokenRequestType tokenRequest)
         {
-            return SendRequest(response => response.registerTokenResponse, tokenRequest);
+            var cnpResponse = SendRequest(response => response, tokenRequest);
+            var tokenResponse = cnpResponse.registerTokenResponse;
+            tokenResponse.location = cnpResponse.location;
+            return tokenResponse;
         }
 
         public voidResponse DoVoid(voidTxn v)
         {
-            return SendRequest(response => response.voidResponse, v);
+            var cnpResponse = SendRequest(response => response, v);
+            var voidResponse = cnpResponse.voidResponse;
+            voidResponse.location = cnpResponse.location;
+            return voidResponse;
         }
 
         public Task<voidResponse> DoVoidAsync(voidTxn v, CancellationToken cancellationToken)
@@ -498,7 +547,10 @@ namespace Cnp.Sdk
 
         public echeckVoidResponse EcheckVoid(echeckVoid v)
         {
-            return SendRequest(response => response.echeckVoidResponse, v);
+            var cnpResponse = SendRequest(response => response, v);
+            var eCheckVoidResponse = cnpResponse.echeckVoidResponse;
+            eCheckVoidResponse.location = cnpResponse.location;
+            return eCheckVoidResponse;
         }
 
         public Task<echeckVoidResponse> EcheckVoidAsync(echeckVoid v, CancellationToken cancellationToken)
@@ -518,17 +570,26 @@ namespace Cnp.Sdk
 
         public cancelSubscriptionResponse CancelSubscription(cancelSubscription cancelSubscription)
         {
-            return SendRequest(response => response.cancelSubscriptionResponse, cancelSubscription);
+            var cnpResponse = SendRequest(response => response, cancelSubscription);
+            var cancelSubscriptionResponse = cnpResponse.cancelSubscriptionResponse;
+            cancelSubscriptionResponse.location = cnpResponse.location;
+            return cancelSubscriptionResponse;
         }
 
         public updateSubscriptionResponse UpdateSubscription(updateSubscription updateSubscription)
         {
-            return SendRequest(response => response.updateSubscriptionResponse, updateSubscription);
+            var cnpResponse = SendRequest(response => response, updateSubscription);
+            var updateSubscriptionResponse = cnpResponse.updateSubscriptionResponse;
+            updateSubscriptionResponse.location = cnpResponse.location;
+            return updateSubscriptionResponse;
         }
 
         public activateResponse Activate(activate activate)
         {
-            return SendRequest(response => response.activateResponse, activate);
+            var cnpResponse = SendRequest(response => response, activate);
+            var activatationResponse = cnpResponse.activateResponse;
+            activatationResponse.location = cnpResponse.location;
+            return activatationResponse;
         }
 
         public deactivateResponse Deactivate(deactivate deactivate)

--- a/CnpSdkForNet/CnpSdkForNet/CnpOnline.cs
+++ b/CnpSdkForNet/CnpSdkForNet/CnpOnline.cs
@@ -904,7 +904,7 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.payFacDebitResponse.location = response.location;
+                response.payoutOrgDebitResponse.location = response.location;
                 return response.payoutOrgDebitResponse;
             }, payoutOrgDebit, cancellationToken);
         }

--- a/CnpSdkForNet/CnpSdkForNet/CnpOnline.cs
+++ b/CnpSdkForNet/CnpSdkForNet/CnpOnline.cs
@@ -9,6 +9,8 @@ using System.Net;
 
 namespace Cnp.Sdk
 {
+    
+
     // Represent an online request.
     // Defining all transactions supported for online processing.
     public class CnpOnline : ICnpOnline
@@ -73,6 +75,11 @@ namespace Cnp.Sdk
         {
             this._communication = communication;
         }
+        
+        //NOTE: in this and other methods location is being set manually due to an issue in the schema, where
+        //CnpOnlineResponse contains location but the inner response does not. For now we're manually setting location
+        //manually within these CnpOnline methods,
+        //but in the future we will remove this code so that location is deserialized automatically
 
         public Task<authorizationResponse> AuthorizeAsync(authorization auth, CancellationToken cancellationToken)
         {
@@ -418,7 +425,6 @@ namespace Cnp.Sdk
                 {
                     captureResponse.location = response.location;
                 }
-
                 return captureResponse;
             }, capture, cancellationToken);
         }

--- a/CnpSdkForNet/CnpSdkForNet/CnpOnline.cs
+++ b/CnpSdkForNet/CnpSdkForNet/CnpOnline.cs
@@ -594,22 +594,34 @@ namespace Cnp.Sdk
 
         public deactivateResponse Deactivate(deactivate deactivate)
         {
-            return SendRequest(response => response.deactivateResponse, deactivate);
+            var cnpResponse = SendRequest(response => response, deactivate);
+            var deactivationResponse = cnpResponse.deactivateResponse;
+            deactivationResponse.location = cnpResponse.location;
+            return deactivationResponse;
         }
 
         public loadResponse Load(load load)
         {
-            return SendRequest(response => response.loadResponse, load);
+            var cnpResponse = SendRequest(response => response, load);
+            var loadResponse = cnpResponse.loadResponse;
+            loadResponse.location = cnpResponse.location;
+            return loadResponse;
         }
 
         public unloadResponse Unload(unload unload)
         {
-            return SendRequest(response => response.unloadResponse, unload);
+            var cnpResponse = SendRequest(response => response, unload);
+            var unloadResponse = cnpResponse.unloadResponse;
+            unloadResponse.location = cnpResponse.location;
+            return unloadResponse;
         }
 
         public balanceInquiryResponse BalanceInquiry(balanceInquiry balanceInquiry)
         {
-            return SendRequest(response => response.balanceInquiryResponse, balanceInquiry);
+            var cnpResponse = SendRequest(response => response, balanceInquiry);
+            var balanceInquiryResponse = cnpResponse.balanceInquiryResponse;
+            balanceInquiryResponse.location = cnpResponse.location;
+            return balanceInquiryResponse;
         }
 
         public Task<balanceInquiryResponse> BalanceInquiryAsync(balanceInquiry balanceInquiry, CancellationToken cancellationToken)
@@ -619,42 +631,66 @@ namespace Cnp.Sdk
 
         public createPlanResponse CreatePlan(createPlan createPlan)
         {
-            return SendRequest(response => response.createPlanResponse, createPlan);
+            var cnpResponse = SendRequest(response => response, createPlan);
+            var createPlanResponse = cnpResponse.createPlanResponse;
+            createPlanResponse.location = cnpResponse.location;
+            return createPlanResponse;
         }
 
         public updatePlanResponse UpdatePlan(updatePlan updatePlan)
         {
-            return SendRequest(response => response.updatePlanResponse, updatePlan);
+            var cnpResponse = SendRequest(response => response, updatePlan);
+            var updatePlanResponse = cnpResponse.updatePlanResponse;
+            updatePlanResponse.location = cnpResponse.location;
+            return updatePlanResponse;
         }
 
         public refundReversalResponse RefundReversal(refundReversal refundReversal)
         {
-            return SendRequest(response => response.refundReversalResponse, refundReversal);
+            var cnpResponse = SendRequest(response => response, refundReversal);
+            var refundReversalResponse = cnpResponse.refundReversalResponse;
+            refundReversalResponse.location = cnpResponse.location;
+            return refundReversalResponse;
         }
 
         public depositReversalResponse DepositReversal(depositReversal depositReversal)
         {
-            return SendRequest(response => response.depositReversalResponse, depositReversal);
+            var cnpResponse = SendRequest(response => response, depositReversal);
+            var depositReversalResponse = cnpResponse.depositReversalResponse;
+            depositReversalResponse.location = cnpResponse.location;
+            return depositReversalResponse;
         }
 
         public activateReversalResponse ActivateReversal(activateReversal activateReversal)
         {
-            return SendRequest(response => response.activateReversalResponse, activateReversal);
+            var cnpResponse = SendRequest(response => response, activateReversal);
+            var activateReversalResponse = cnpResponse.activateReversalResponse;
+            activateReversalResponse.location = cnpResponse.location;
+            return activateReversalResponse;
         }
 
         public deactivateReversalResponse DeactivateReversal(deactivateReversal deactivateReversal)
         {
-            return SendRequest(response => response.deactivateReversalResponse, deactivateReversal);
+            var cnpResponse = SendRequest(response => response, deactivateReversal);
+            var deactivateReversalResponse = cnpResponse.deactivateReversalResponse;
+            deactivateReversalResponse.location = cnpResponse.location;
+            return deactivateReversalResponse;
         }
 
         public loadReversalResponse LoadReversal(loadReversal loadReversal)
         {
-            return SendRequest(response => response.loadReversalResponse, loadReversal);
+            var cnpResponse = SendRequest(response => response, loadReversal);
+            var loadReversalResponse = cnpResponse.loadReversalResponse;
+            loadReversalResponse.location = cnpResponse.location;
+            return loadReversalResponse;
         }
 
         public unloadReversalResponse UnloadReversal(unloadReversal unloadReversal)
         {
-            return SendRequest(response => response.unloadReversalResponse, unloadReversal);
+            var cnpResponse = SendRequest(response => response, unloadReversal);
+            var unloadReversalResponse = cnpResponse.unloadReversalResponse;
+            unloadReversalResponse.location = cnpResponse.location;
+            return unloadReversalResponse;
         }
 
         public Task<transactionTypeWithReportGroup> QueryTransactionAsync(queryTransaction queryTransaction, CancellationToken cancellationToken)
@@ -664,22 +700,35 @@ namespace Cnp.Sdk
 
         public transactionTypeWithReportGroup QueryTransaction(queryTransaction queryTransaction)
         {
-            return SendRequest(response =>(response.queryTransactionResponse ?? (transactionTypeWithReportGroup)response.queryTransactionUnavailableResponse), queryTransaction);
+            var cnpResponse = SendRequest(response => response, queryTransaction);
+            var transactionResponse = cnpResponse.queryTransactionResponse ??
+                                      (transactionTypeWithReportGroup) cnpResponse.queryTransactionUnavailableResponse;
+            transactionResponse.location = cnpResponse.location;
+            return transactionResponse;
         }
 
         public fraudCheckResponse FraudCheck(fraudCheck fraudCheck)
         {
-            return SendRequest(response => response.fraudCheckResponse, fraudCheck);
+            var cnpResponse = SendRequest(response => response, fraudCheck);
+            var fraudCheckResponse = cnpResponse.fraudCheckResponse;
+            fraudCheckResponse.location = cnpResponse.location;
+            return fraudCheckResponse;
         }
 
         public fastAccessFundingResponse FastAccessFunding(fastAccessFunding fastAccessFunding)
         {
-            return SendRequest(response => response.fastAccessFundingResponse, fastAccessFunding);
+            var cnpResponse = SendRequest(response => response, fastAccessFunding);
+            var fastAccessFundingResponse = cnpResponse.fastAccessFundingResponse;
+            fastAccessFundingResponse.location = cnpResponse.location;
+            return fastAccessFundingResponse;
         }
         
         public payFacCreditResponse PayFacCredit(payFacCredit payFacCredit)
         {
-            return SendRequest(response => response.payFacCreditResponse, payFacCredit);
+            var cnpResponse = SendRequest(response => response, payFacCredit);
+            var payFacCreditResponse = cnpResponse.payFacCreditResponse;
+            payFacCreditResponse.location = cnpResponse.location;
+            return payFacCreditResponse;
         }
 
         public Task<payFacCreditResponse> PayFacCreditAsync(payFacCredit payFacCredit, CancellationToken cancellationToken)
@@ -689,7 +738,10 @@ namespace Cnp.Sdk
 
         public payFacDebitResponse PayFacDebit(payFacDebit payFacDebit)
         {
-            return SendRequest(response => response.payFacDebitResponse, payFacDebit);
+            var cnpResponse = SendRequest(response => response, payFacDebit);
+            var payfacDebitResponse = cnpResponse.payFacDebitResponse;
+            payfacDebitResponse.location = cnpResponse.location;
+            return payfacDebitResponse;
         }
 
         public Task<payFacDebitResponse> PayFacDebitAsync(payFacDebit payFacDebit, CancellationToken cancellationToken)
@@ -699,7 +751,10 @@ namespace Cnp.Sdk
 
         public physicalCheckCreditResponse PhysicalCheckCredit(physicalCheckCredit physicalCheckCredit)
         {
-            return SendRequest(response => response.physicalCheckCreditResponse, physicalCheckCredit);
+            var cnpResponse = SendRequest(response => response, physicalCheckCredit);
+            var physicalCheckCreditResponse = cnpResponse.physicalCheckCreditResponse;
+            physicalCheckCreditResponse.location = cnpResponse.location;
+            return physicalCheckCreditResponse;
         }
 
         public Task<physicalCheckCreditResponse> PhysicalCheckCreditAsync(physicalCheckCredit physicalCheckCredit, CancellationToken cancellationToken)
@@ -709,7 +764,10 @@ namespace Cnp.Sdk
 
         public physicalCheckDebitResponse PhysicalCheckDebit(physicalCheckDebit physicalCheckDebit)
         {
-            return SendRequest(response => response.physicalCheckDebitResponse, physicalCheckDebit);
+            var cnpResponse = SendRequest(response => response, physicalCheckDebit);
+            var physicalCheckDebitResponse = cnpResponse.physicalCheckDebitResponse;
+            physicalCheckDebitResponse.location = cnpResponse.location;
+            return physicalCheckDebitResponse;
         }
 
         public Task<physicalCheckDebitResponse> PhysicalCheckDebitAsync(physicalCheckDebit physicalCheckDebit, CancellationToken cancellationToken)
@@ -719,7 +777,10 @@ namespace Cnp.Sdk
 
         public payoutOrgCreditResponse PayoutOrgCredit(payoutOrgCredit payoutOrgCredit)
         {
-            return SendRequest(response => response.payoutOrgCreditResponse, payoutOrgCredit);
+            var cnpResponse = SendRequest(response => response, payoutOrgCredit);
+            var payoutOrgCreditResponse = cnpResponse.payoutOrgCreditResponse;
+            payoutOrgCreditResponse.location = cnpResponse.location;
+            return payoutOrgCreditResponse;
         }
 
         public Task<payoutOrgCreditResponse> PayoutOrgCreditAsync(payoutOrgCredit payoutOrgCredit, CancellationToken cancellationToken)
@@ -729,7 +790,10 @@ namespace Cnp.Sdk
 
         public payoutOrgDebitResponse PayoutOrgDebit(payoutOrgDebit payoutOrgDebit)
         {
-            return SendRequest(response => response.payoutOrgDebitResponse, payoutOrgDebit);
+            var cnpResponse = SendRequest(response => response, payoutOrgDebit);
+            var payoutOrgDebitResponse = cnpResponse.payoutOrgDebitResponse;
+            payoutOrgDebitResponse.location = cnpResponse.location;
+            return payoutOrgDebitResponse;
         }
 
         public Task<payoutOrgDebitResponse> PayoutOrgDebitAsync(payoutOrgDebit payoutOrgDebit, CancellationToken cancellationToken)
@@ -739,7 +803,10 @@ namespace Cnp.Sdk
 
         public reserveCreditResponse ReserveCredit(reserveCredit reserveCredit)
         {
-            return SendRequest(response => response.reserveCreditResponse, reserveCredit);
+            var cnpResponse = SendRequest(response => response, reserveCredit);
+            var reserveCreditResponse = cnpResponse.reserveCreditResponse;
+            reserveCreditResponse.location = cnpResponse.location;
+            return reserveCreditResponse;
         }
 
         public Task<reserveCreditResponse> ReserveCreditAsync(reserveCredit reserveCredit, CancellationToken cancellationToken)
@@ -749,7 +816,10 @@ namespace Cnp.Sdk
 
         public reserveDebitResponse ReserveDebit(reserveDebit reserveDebit)
         {
-            return SendRequest(response => response.reserveDebitResponse, reserveDebit);
+            var cnpResponse = SendRequest(response => response, reserveDebit);
+            var reserveDebitResponse = cnpResponse.reserveDebitResponse;
+            reserveDebitResponse.location = cnpResponse.location;
+            return reserveDebitResponse;
         }
 
         public Task<reserveDebitResponse> ReserveDebitAsync(reserveDebit reserveDebit, CancellationToken cancellationToken)
@@ -759,7 +829,10 @@ namespace Cnp.Sdk
 
         public submerchantCreditResponse SubmerchantCredit(submerchantCredit submerchantCredit)
         {
-            return SendRequest(response => response.submerchantCreditResponse, submerchantCredit);
+            var cnpResponse = SendRequest(response => response, submerchantCredit);
+            var submerchantCreditResponse = cnpResponse.submerchantCreditResponse;
+            submerchantCreditResponse.location = cnpResponse.location;
+            return submerchantCreditResponse;
         }
 
         public Task<submerchantCreditResponse> SubmerchantCreditAsync(submerchantCredit submerchantCredit, CancellationToken cancellationToken)
@@ -769,7 +842,10 @@ namespace Cnp.Sdk
 
         public submerchantDebitResponse SubmerchantDebit(submerchantDebit submerchantDebit)
         {
-            return SendRequest(response => response.submerchantDebitResponse, submerchantDebit);
+            var cnpResponse = SendRequest(response => response, submerchantDebit);
+            var submerchantDebitResponse = cnpResponse.submerchantDebitResponse;
+            submerchantDebitResponse.location = cnpResponse.location;
+            return submerchantDebitResponse;
         }
 
         public Task<submerchantDebitResponse> SubmerchantDebitAsync(submerchantDebit submerchantDebit, CancellationToken cancellationToken)
@@ -779,7 +855,10 @@ namespace Cnp.Sdk
 
         public vendorCreditResponse VendorCredit(vendorCredit vendorCredit)
         {
-            return SendRequest(response => response.vendorCreditResponse, vendorCredit);
+            var cnpResponse = SendRequest(response => response, vendorCredit);
+            var vendorCreditResponse = cnpResponse.vendorCreditResponse;
+            vendorCreditResponse.location = cnpResponse.location;
+            return vendorCreditResponse;
         }
 
         public Task<vendorCreditResponse> VendorCreditAsync(vendorCredit vendorCredit, CancellationToken cancellationToken)
@@ -789,7 +868,10 @@ namespace Cnp.Sdk
 
         public customerCreditResponse CustomerCredit(customerCredit customerCredit)
         {
-            return SendRequest(response => response.customerCreditResponse, customerCredit);
+            var cnpResponse = SendRequest(response => response, customerCredit);
+            var customerCreditResponse = cnpResponse.customerCreditResponse;
+            customerCreditResponse.location = cnpResponse.location;
+            return customerCreditResponse;
         }
 
         public Task<customerCreditResponse> CustomerCreditAsync(customerCredit customerCredit, CancellationToken cancellationToken)
@@ -799,7 +881,10 @@ namespace Cnp.Sdk
 
         public translateToLowValueTokenResponse TranslateToLowValueTokenRequest(translateToLowValueTokenRequest translateToLowValueTokenRequest)
         {
-            return SendRequest(response => response.translateToLowValueTokenResponse, translateToLowValueTokenRequest);
+            var cnpResponse = SendRequest(response => response, translateToLowValueTokenRequest);
+            var translateToLowValueTokenResponse = cnpResponse.translateToLowValueTokenResponse;
+            translateToLowValueTokenResponse.location = cnpResponse.location;
+            return translateToLowValueTokenResponse;
         }
 
         public Task<translateToLowValueTokenResponse> TranslateToLowValueTokenRequestAsync(translateToLowValueTokenRequest translateToLowValueTokenRequest, CancellationToken cancellationToken)
@@ -809,7 +894,10 @@ namespace Cnp.Sdk
 
         public vendorDebitResponse VendorDebit(vendorDebit vendorDebit)
         {
-            return SendRequest(response => response.vendorDebitResponse, vendorDebit);
+            var cnpResponse = SendRequest(response => response, vendorDebit);
+            var vendorDebitResponse = cnpResponse.vendorDebitResponse;
+            vendorDebitResponse.location = cnpResponse.location;
+            return vendorDebitResponse;
         }
 
         public Task<vendorDebitResponse> VendorDebitAsync(vendorDebit vendorDebit, CancellationToken cancellationToken)
@@ -819,7 +907,10 @@ namespace Cnp.Sdk
 
         public customerDebitResponse CustomerDebit(customerDebit customerDebit)
         {
-            return SendRequest(response => response.customerDebitResponse, customerDebit);
+            var cnpResponse = SendRequest(response => response, customerDebit);
+            var customerDebitResponse = cnpResponse.customerDebitResponse;
+            customerDebitResponse.location = cnpResponse.location;
+            return customerDebitResponse;
         }
 
         public Task<customerDebitResponse> CustomerDebitAsync(customerDebit customerDebit, CancellationToken cancellationToken)

--- a/CnpSdkForNet/CnpSdkForNet/CnpOnline.cs
+++ b/CnpSdkForNet/CnpSdkForNet/CnpOnline.cs
@@ -360,7 +360,11 @@ namespace Cnp.Sdk
 
         public Task<authReversalResponse> AuthReversalAsync(authReversal reversal, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.authReversalResponse, reversal, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.authReversalResponse.location = response.location;
+                return response.authReversalResponse;
+            }, reversal, cancellationToken);
         }
 
         public giftCardAuthReversalResponse GiftCardAuthReversal(giftCardAuthReversal giftCard)
@@ -373,12 +377,20 @@ namespace Cnp.Sdk
 
         public Task<giftCardAuthReversalResponse> GiftCardAuthReversalAsync(giftCardAuthReversal giftCard, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.giftCardAuthReversalResponse, giftCard, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.giftCardAuthReversalResponse.location = response.location;
+                return response.giftCardAuthReversalResponse;
+            }, giftCard, cancellationToken);
         }
 
         public Task<captureResponse> CaptureAsync(capture capture, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.captureResponse, capture, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.captureResponse.location = response.location;
+                return response.captureResponse;
+            }, capture, cancellationToken);
         }
 
         public captureResponse Capture(capture capture)
@@ -399,12 +411,21 @@ namespace Cnp.Sdk
 
         public Task<giftCardCaptureResponse> GiftCardCaptureAsync(giftCardCapture giftCardCapture, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.giftCardCaptureResponse, giftCardCapture, cancellationToken);
+            
+            return SendRequestAsync(response =>
+            {
+                response.giftCardCaptureResponse.location = response.location;
+                return response.giftCardCaptureResponse;
+            }, giftCardCapture, cancellationToken);
         }
 
         public Task<captureGivenAuthResponse> CaptureGivenAuthAsync(captureGivenAuth captureGivenAuth, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.captureGivenAuthResponse, captureGivenAuth, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.captureGivenAuthResponse.location = response.location;
+                return response.captureGivenAuthResponse;
+            }, captureGivenAuth, cancellationToken);
         }
 
         public captureGivenAuthResponse CaptureGivenAuth(captureGivenAuth captureGivenAuth)
@@ -425,7 +446,11 @@ namespace Cnp.Sdk
 
         public Task<creditResponse> CreditAsync(credit credit, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.creditResponse, credit, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.creditResponse.location = response.location;
+                return response.creditResponse;
+            }, credit, cancellationToken);
         }
 
         public giftCardCreditResponse GiftCardCredit(giftCardCredit giftCardCredit)
@@ -438,12 +463,20 @@ namespace Cnp.Sdk
 
         public Task<giftCardCreditResponse> GiftCardCreditAsync(giftCardCredit giftCardCredit, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.giftCardCreditResponse, giftCardCredit, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.giftCardCreditResponse.location = response.location;
+                return response.giftCardCreditResponse;
+            }, giftCardCredit, cancellationToken);
         }
 
         public Task<echeckCreditResponse> EcheckCreditAsync(echeckCredit echeckCredit, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.echeckCreditResponse, echeckCredit, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.echeckCreditResponse.location = response.location;
+                return response.echeckCreditResponse;
+            }, echeckCredit, cancellationToken);
         }
 
         public echeckCreditResponse EcheckCredit(echeckCredit echeckCredit)
@@ -456,7 +489,11 @@ namespace Cnp.Sdk
 
         public Task<echeckRedepositResponse> EcheckRedepositAsync(echeckRedeposit echeckRedeposit, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.echeckRedepositResponse, echeckRedeposit, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.echeckRedepositResponse.location = response.location;
+                return response.echeckRedepositResponse;
+            }, echeckRedeposit, cancellationToken);
         }
 
         public echeckRedepositResponse EcheckRedeposit(echeckRedeposit echeckRedeposit)
@@ -469,7 +506,12 @@ namespace Cnp.Sdk
 
         public Task<echeckSalesResponse> EcheckSaleAsync(echeckSale echeckSale, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.echeckSalesResponse, echeckSale, cancellationToken);
+            
+            return SendRequestAsync(response =>
+            {
+                response.echeckSalesResponse.location = response.location;
+                return response.echeckSalesResponse;
+            }, echeckSale, cancellationToken);
         }
 
         public echeckSalesResponse EcheckSale(echeckSale echeckSale)
@@ -490,7 +532,11 @@ namespace Cnp.Sdk
 
         public Task<echeckVerificationResponse> EcheckVerificationAsync(echeckVerification echeckVerification, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.echeckVerificationResponse, echeckVerification, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.echeckVerificationResponse.location = response.location;
+                return response.echeckVerificationResponse;
+            }, echeckVerification, cancellationToken);
         }
 
         public forceCaptureResponse ForceCapture(forceCapture forceCapture)
@@ -503,7 +549,11 @@ namespace Cnp.Sdk
 
         public Task<forceCaptureResponse> ForceCaptureAsync(forceCapture forceCapture, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.forceCaptureResponse, forceCapture, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.forceCaptureResponse.location = response.location;
+                return response.forceCaptureResponse;
+            }, forceCapture, cancellationToken);
         }
 
         public saleResponse Sale(sale sale)
@@ -516,12 +566,20 @@ namespace Cnp.Sdk
 
         public Task<saleResponse> SaleAsync(sale sale, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.saleResponse, sale, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.saleResponse.location = response.location;
+                return response.saleResponse;
+            }, sale, cancellationToken);
         }
 
         public Task<registerTokenResponse> RegisterTokenAsync(registerTokenRequestType tokenRequest, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.registerTokenResponse, tokenRequest, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.registerTokenResponse.location = response.location;
+                return response.registerTokenResponse;
+            }, tokenRequest, cancellationToken);
         }
 
         public registerTokenResponse RegisterToken(registerTokenRequestType tokenRequest)
@@ -542,7 +600,11 @@ namespace Cnp.Sdk
 
         public Task<voidResponse> DoVoidAsync(voidTxn v, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.voidResponse, v, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.voidResponse.location = response.location;
+                return response.voidResponse;
+            }, v, cancellationToken);
         }
 
         public echeckVoidResponse EcheckVoid(echeckVoid v)
@@ -555,17 +617,29 @@ namespace Cnp.Sdk
 
         public Task<echeckVoidResponse> EcheckVoidAsync(echeckVoid v, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.echeckVoidResponse, v, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.echeckVoidResponse.location = response.location;
+                return response.echeckVoidResponse;
+            }, v, cancellationToken);
         }
 
         public updateCardValidationNumOnTokenResponse UpdateCardValidationNumOnToken(updateCardValidationNumOnToken updateCardValidationNumOnToken)
         {
-            return SendRequest(response => response.updateCardValidationNumOnTokenResponse, updateCardValidationNumOnToken);
+            return SendRequest(response =>
+            {
+                response.updateCardValidationNumOnTokenResponse.location = response.location;
+                return response.updateCardValidationNumOnTokenResponse;
+            }, updateCardValidationNumOnToken);
         }
 
         public Task<updateCardValidationNumOnTokenResponse> UpdateCardValidationNumOnTokenAsync(updateCardValidationNumOnToken update, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.updateCardValidationNumOnTokenResponse, update, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.updateCardValidationNumOnTokenResponse.location = response.location;
+                return response.updateCardValidationNumOnTokenResponse;
+            }, update, cancellationToken);
         }
 
         public cancelSubscriptionResponse CancelSubscription(cancelSubscription cancelSubscription)
@@ -626,7 +700,11 @@ namespace Cnp.Sdk
 
         public Task<balanceInquiryResponse> BalanceInquiryAsync(balanceInquiry balanceInquiry, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.balanceInquiryResponse, balanceInquiry, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.balanceInquiryResponse.location = response.location;
+                return response.balanceInquiryResponse;
+            }, balanceInquiry, cancellationToken);
         }
 
         public createPlanResponse CreatePlan(createPlan createPlan)
@@ -695,7 +773,13 @@ namespace Cnp.Sdk
 
         public Task<transactionTypeWithReportGroup> QueryTransactionAsync(queryTransaction queryTransaction, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => (response.queryTransactionResponse ?? (transactionTypeWithReportGroup)response.queryTransactionUnavailableResponse), queryTransaction, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                var res = response.queryTransactionResponse ??
+                        (transactionTypeWithReportGroup) response.queryTransactionUnavailableResponse;
+                res.location = response.location;
+                return res;
+            }, queryTransaction, cancellationToken);
         }
 
         public transactionTypeWithReportGroup QueryTransaction(queryTransaction queryTransaction)
@@ -733,7 +817,11 @@ namespace Cnp.Sdk
 
         public Task<payFacCreditResponse> PayFacCreditAsync(payFacCredit payFacCredit, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.payFacCreditResponse, payFacCredit, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.payFacCreditResponse.location = response.location;
+                return response.payFacCreditResponse;
+            }, payFacCredit, cancellationToken);
         }
 
         public payFacDebitResponse PayFacDebit(payFacDebit payFacDebit)
@@ -746,7 +834,11 @@ namespace Cnp.Sdk
 
         public Task<payFacDebitResponse> PayFacDebitAsync(payFacDebit payFacDebit, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.payFacDebitResponse, payFacDebit, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.payFacDebitResponse.location = response.location;
+                return response.payFacDebitResponse;
+            }, payFacDebit, cancellationToken);
         }
 
         public physicalCheckCreditResponse PhysicalCheckCredit(physicalCheckCredit physicalCheckCredit)
@@ -759,7 +851,11 @@ namespace Cnp.Sdk
 
         public Task<physicalCheckCreditResponse> PhysicalCheckCreditAsync(physicalCheckCredit physicalCheckCredit, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.physicalCheckCreditResponse, physicalCheckCredit, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.physicalCheckCreditResponse.location = response.location;
+                return response.physicalCheckCreditResponse;
+            }, physicalCheckCredit, cancellationToken);
         }
 
         public physicalCheckDebitResponse PhysicalCheckDebit(physicalCheckDebit physicalCheckDebit)
@@ -772,7 +868,11 @@ namespace Cnp.Sdk
 
         public Task<physicalCheckDebitResponse> PhysicalCheckDebitAsync(physicalCheckDebit physicalCheckDebit, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.physicalCheckDebitResponse, physicalCheckDebit, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.physicalCheckDebitResponse.location = response.location;
+                return response.physicalCheckDebitResponse;
+            }, physicalCheckDebit, cancellationToken);
         }
 
         public payoutOrgCreditResponse PayoutOrgCredit(payoutOrgCredit payoutOrgCredit)
@@ -785,7 +885,11 @@ namespace Cnp.Sdk
 
         public Task<payoutOrgCreditResponse> PayoutOrgCreditAsync(payoutOrgCredit payoutOrgCredit, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.payoutOrgCreditResponse, payoutOrgCredit, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.payoutOrgCreditResponse.location = response.location;
+                return response.payoutOrgCreditResponse;
+            }, payoutOrgCredit, cancellationToken);
         }
 
         public payoutOrgDebitResponse PayoutOrgDebit(payoutOrgDebit payoutOrgDebit)
@@ -798,7 +902,11 @@ namespace Cnp.Sdk
 
         public Task<payoutOrgDebitResponse> PayoutOrgDebitAsync(payoutOrgDebit payoutOrgDebit, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.payoutOrgDebitResponse, payoutOrgDebit, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.payFacDebitResponse.location = response.location;
+                return response.payoutOrgDebitResponse;
+            }, payoutOrgDebit, cancellationToken);
         }
 
         public reserveCreditResponse ReserveCredit(reserveCredit reserveCredit)
@@ -811,7 +919,11 @@ namespace Cnp.Sdk
 
         public Task<reserveCreditResponse> ReserveCreditAsync(reserveCredit reserveCredit, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.reserveCreditResponse, reserveCredit, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.reserveCreditResponse.location = response.location;
+                return response.reserveCreditResponse;
+            }, reserveCredit, cancellationToken);
         }
 
         public reserveDebitResponse ReserveDebit(reserveDebit reserveDebit)
@@ -824,7 +936,11 @@ namespace Cnp.Sdk
 
         public Task<reserveDebitResponse> ReserveDebitAsync(reserveDebit reserveDebit, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.reserveDebitResponse, reserveDebit, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.reserveDebitResponse.location = response.location;
+                return response.reserveDebitResponse;
+            }, reserveDebit, cancellationToken);
         }
 
         public submerchantCreditResponse SubmerchantCredit(submerchantCredit submerchantCredit)
@@ -837,7 +953,11 @@ namespace Cnp.Sdk
 
         public Task<submerchantCreditResponse> SubmerchantCreditAsync(submerchantCredit submerchantCredit, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.submerchantCreditResponse, submerchantCredit, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.submerchantCreditResponse.location = response.location;
+                return response.submerchantCreditResponse;
+            }, submerchantCredit, cancellationToken);
         }
 
         public submerchantDebitResponse SubmerchantDebit(submerchantDebit submerchantDebit)
@@ -850,7 +970,11 @@ namespace Cnp.Sdk
 
         public Task<submerchantDebitResponse> SubmerchantDebitAsync(submerchantDebit submerchantDebit, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.submerchantDebitResponse, submerchantDebit, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.submerchantDebitResponse.location = response.location;
+                return response.submerchantDebitResponse;
+            }, submerchantDebit, cancellationToken);
         }
 
         public vendorCreditResponse VendorCredit(vendorCredit vendorCredit)
@@ -863,7 +987,11 @@ namespace Cnp.Sdk
 
         public Task<vendorCreditResponse> VendorCreditAsync(vendorCredit vendorCredit, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.vendorCreditResponse, vendorCredit, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.vendorCreditResponse.location = response.location;
+                return response.vendorCreditResponse;
+            }, vendorCredit, cancellationToken);
         }
 
         public customerCreditResponse CustomerCredit(customerCredit customerCredit)
@@ -876,7 +1004,11 @@ namespace Cnp.Sdk
 
         public Task<customerCreditResponse> CustomerCreditAsync(customerCredit customerCredit, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.customerCreditResponse, customerCredit, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.customerCreditResponse.location = response.location;
+                return response.customerCreditResponse;
+            }, customerCredit, cancellationToken);
         }
 
         public translateToLowValueTokenResponse TranslateToLowValueTokenRequest(translateToLowValueTokenRequest translateToLowValueTokenRequest)
@@ -889,7 +1021,11 @@ namespace Cnp.Sdk
 
         public Task<translateToLowValueTokenResponse> TranslateToLowValueTokenRequestAsync(translateToLowValueTokenRequest translateToLowValueTokenRequest, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.translateToLowValueTokenResponse, translateToLowValueTokenRequest, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.translateToLowValueTokenResponse.location = response.location;
+                return response.translateToLowValueTokenResponse;
+            }, translateToLowValueTokenRequest, cancellationToken);
         }
 
         public vendorDebitResponse VendorDebit(vendorDebit vendorDebit)
@@ -902,7 +1038,11 @@ namespace Cnp.Sdk
 
         public Task<vendorDebitResponse> VendorDebitAsync(vendorDebit vendorDebit, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.vendorDebitResponse, vendorDebit, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.vendorDebitResponse.location = response.location;
+                return response.vendorDebitResponse;
+            }, vendorDebit, cancellationToken);
         }
 
         public customerDebitResponse CustomerDebit(customerDebit customerDebit)
@@ -915,7 +1055,11 @@ namespace Cnp.Sdk
 
         public Task<customerDebitResponse> CustomerDebitAsync(customerDebit customerDebit, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.customerDebitResponse, customerDebit, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                response.customerDebitResponse.location = response.location;
+                return response.customerDebitResponse;
+            }, customerDebit, cancellationToken);
         }
 
 

--- a/CnpSdkForNet/CnpSdkForNet/CnpOnline.cs
+++ b/CnpSdkForNet/CnpSdkForNet/CnpOnline.cs
@@ -345,7 +345,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse =  SendRequest(response => response, auth);
             var authResponse = cnpResponse.authorizationResponse;
-            authResponse.location = cnpResponse.location;
+            if (authResponse != null)
+            {
+                authResponse.location = cnpResponse.location;
+            }
             return authResponse;
         }
 
@@ -354,7 +357,10 @@ namespace Cnp.Sdk
             
             var cnpResponse =  SendRequest(response => response, reversal);
             var reversalResponse = cnpResponse.authReversalResponse;
-            reversalResponse.location = cnpResponse.location;
+            if (reversalResponse != null)
+            {
+                reversalResponse.location = cnpResponse.location;
+            }
             return reversalResponse;
         }
 
@@ -362,8 +368,12 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.authReversalResponse.location = response.location;
-                return response.authReversalResponse;
+                var authReversalResponse = response.authReversalResponse;
+                if (authReversalResponse != null)
+                {
+                    response.authReversalResponse.location = response.location;
+                }
+                return authReversalResponse;
             }, reversal, cancellationToken);
         }
 
@@ -371,7 +381,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse =  SendRequest(response => response, giftCard);
             var giftCardReversalResponse = cnpResponse.giftCardAuthReversalResponse;
-            giftCardReversalResponse.location = cnpResponse.location;
+            if (giftCardReversalResponse != null)
+            {
+                giftCardReversalResponse.location = cnpResponse.location;
+            }
             return giftCardReversalResponse;
         }
 
@@ -379,8 +392,12 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.giftCardAuthReversalResponse.location = response.location;
-                return response.giftCardAuthReversalResponse;
+                var giftCardAuthReversalResponse = response.giftCardAuthReversalResponse;
+                if (giftCardAuthReversalResponse != null)
+                {
+                    giftCardAuthReversalResponse.location = response.location;
+                }
+                return giftCardAuthReversalResponse;
             }, giftCard, cancellationToken);
         }
 
@@ -388,8 +405,13 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.captureResponse.location = response.location;
-                return response.captureResponse;
+                var captureResponse = response.captureResponse;
+                if (captureResponse != null)
+                {
+                    captureResponse.location = response.location;
+                }
+
+                return captureResponse;
             }, capture, cancellationToken);
         }
 
@@ -397,7 +419,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse =  SendRequest(response => response, capture);
             var captureResponse = cnpResponse.captureResponse;
-            captureResponse.location = cnpResponse.location;
+            if (captureResponse != null)
+            {
+                captureResponse.location = cnpResponse.location;
+            }
             return captureResponse;
         }
 
@@ -405,7 +430,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse =  SendRequest(response => response, giftCardCapture);
             var giftCaptureResponse = cnpResponse.giftCardCaptureResponse;
-            giftCaptureResponse.location = cnpResponse.location;
+            if (giftCaptureResponse != null)
+            {
+                giftCaptureResponse.location = cnpResponse.location;
+            }
             return giftCaptureResponse;
         }
 
@@ -414,8 +442,12 @@ namespace Cnp.Sdk
             
             return SendRequestAsync(response =>
             {
-                response.giftCardCaptureResponse.location = response.location;
-                return response.giftCardCaptureResponse;
+                var giftCardCaptureResponse = response.giftCardCaptureResponse;
+                if (giftCardCaptureResponse != null)
+                {
+                    giftCardCaptureResponse.location = response.location;
+                }
+                return giftCardCaptureResponse;
             }, giftCardCapture, cancellationToken);
         }
 
@@ -423,7 +455,11 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.captureGivenAuthResponse.location = response.location;
+                var captureGivenAuthResponse = response.captureGivenAuthResponse;
+                if (captureGivenAuthResponse != null)
+                {
+                    captureGivenAuthResponse.location = response.location;
+                }
                 return response.captureGivenAuthResponse;
             }, captureGivenAuth, cancellationToken);
         }
@@ -432,7 +468,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, captureGivenAuth);
             var captureAuthResponse = cnpResponse.captureGivenAuthResponse;
-            captureAuthResponse.location = cnpResponse.location;
+            if (captureAuthResponse != null)
+            {
+                captureAuthResponse.location = cnpResponse.location;
+            }
             return captureAuthResponse;
         }
 
@@ -440,7 +479,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, credit);
             var creditResponse = cnpResponse.creditResponse;
-            creditResponse.location = cnpResponse.location;
+            if (creditResponse != null)
+            {
+                creditResponse.location = cnpResponse.location;
+            }
             return creditResponse;
         }
 
@@ -448,8 +490,12 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.creditResponse.location = response.location;
-                return response.creditResponse;
+                var creditResponse= response.creditResponse;
+                if (creditResponse != null)
+                {
+                    creditResponse.location = response.location;
+                }
+                return creditResponse;
             }, credit, cancellationToken);
         }
 
@@ -457,7 +503,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, giftCardCredit);
             var giftCreditResponse = cnpResponse.giftCardCreditResponse;
-            giftCreditResponse.location = cnpResponse.location;
+            if (giftCreditResponse != null)
+            {
+                giftCreditResponse.location = cnpResponse.location;
+            }
             return giftCreditResponse;
         }
 
@@ -465,7 +514,11 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.giftCardCreditResponse.location = response.location;
+                var giftCardCreditResponse = response.giftCardCreditResponse;
+                if (giftCardCreditResponse != null)
+                {
+                    giftCardCreditResponse.location = response.location;
+                }
                 return response.giftCardCreditResponse;
             }, giftCardCredit, cancellationToken);
         }
@@ -474,7 +527,11 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.echeckCreditResponse.location = response.location;
+                var echeckCreditResponse = response.echeckCreditResponse;
+                if (echeckCreditResponse != null)
+                {
+                    echeckCreditResponse.location = response.location;
+                }
                 return response.echeckCreditResponse;
             }, echeckCredit, cancellationToken);
         }
@@ -483,7 +540,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, echeckCredit);
             var eCheckCreditResponse = cnpResponse.echeckCreditResponse;
-            eCheckCreditResponse.location = cnpResponse.location;
+            if (eCheckCreditResponse != null)
+            {
+                eCheckCreditResponse.location = cnpResponse.location;
+            }
             return eCheckCreditResponse;
         }
 
@@ -491,8 +551,13 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.echeckRedepositResponse.location = response.location;
-                return response.echeckRedepositResponse;
+                var echeckRedepositResponse = response.echeckRedepositResponse;
+                if (echeckRedepositResponse != null)
+                {
+                    echeckRedepositResponse.location = response.location;
+                }
+
+                return echeckRedepositResponse;
             }, echeckRedeposit, cancellationToken);
         }
 
@@ -500,7 +565,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, echeckRedeposit);
             var eCheckRedepositResponse = cnpResponse.echeckRedepositResponse;
-            eCheckRedepositResponse.location = cnpResponse.location;
+            if (eCheckRedepositResponse != null)
+            {
+                eCheckRedepositResponse.location = cnpResponse.location;
+            }
             return eCheckRedepositResponse;
         }
 
@@ -509,8 +577,12 @@ namespace Cnp.Sdk
             
             return SendRequestAsync(response =>
             {
-                response.echeckSalesResponse.location = response.location;
-                return response.echeckSalesResponse;
+                var echeckSalesResponse = response.echeckSalesResponse;
+                if (echeckSalesResponse != null)
+                {
+                    echeckSalesResponse.location = response.location;
+                }
+                return echeckSalesResponse;
             }, echeckSale, cancellationToken);
         }
 
@@ -518,7 +590,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, echeckSale);
             var eCheckSaleResponse = cnpResponse.echeckSalesResponse;
-            eCheckSaleResponse.location = cnpResponse.location;
+            if (eCheckSaleResponse != null)
+            {
+                eCheckSaleResponse.location = cnpResponse.location;
+            }
             return eCheckSaleResponse;
         }
 
@@ -526,7 +601,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, echeckVerification);
             var eCheckVerificationResponse = cnpResponse.echeckVerificationResponse;
-            eCheckVerificationResponse.location = cnpResponse.location;
+            if (eCheckVerificationResponse != null)
+            {
+                eCheckVerificationResponse.location = cnpResponse.location;
+            }
             return eCheckVerificationResponse;
         }
 
@@ -534,8 +612,12 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.echeckVerificationResponse.location = response.location;
-                return response.echeckVerificationResponse;
+                var echeckVerificationResponse = response.echeckVerificationResponse;
+                if (echeckVerificationResponse != null)
+                {
+                    echeckVerificationResponse.location = response.location;
+                }
+                return echeckVerificationResponse;
             }, echeckVerification, cancellationToken);
         }
 
@@ -543,7 +625,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, forceCapture);
             var forceCaptureResponse = cnpResponse.forceCaptureResponse;
-            forceCaptureResponse.location = cnpResponse.location;
+            if (forceCaptureResponse != null)
+            {
+                forceCaptureResponse.location = cnpResponse.location;
+            }
             return forceCaptureResponse;
         }
 
@@ -551,8 +636,12 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.forceCaptureResponse.location = response.location;
-                return response.forceCaptureResponse;
+                var forceCaptureResponse = response.forceCaptureResponse;
+                if (forceCaptureResponse != null)
+                {
+                    forceCaptureResponse.location = response.location;
+                }
+                return forceCaptureResponse;
             }, forceCapture, cancellationToken);
         }
 
@@ -560,7 +649,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, sale);
             var saleResponse = cnpResponse.saleResponse;
-            saleResponse.location = cnpResponse.location;
+            if (saleResponse != null)
+            {
+                saleResponse.location = cnpResponse.location;
+            }
             return saleResponse;
         }
 
@@ -568,8 +660,12 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.saleResponse.location = response.location;
-                return response.saleResponse;
+                var saleResponse = response.saleResponse;
+                if (saleResponse != null)
+                {
+                    saleResponse.location = response.location;
+                }
+                return saleResponse;
             }, sale, cancellationToken);
         }
 
@@ -577,7 +673,11 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.registerTokenResponse.location = response.location;
+                var registerTokenResponse = response.registerTokenResponse;
+                if (registerTokenResponse != null)
+                {
+                    registerTokenResponse.location = response.location;
+                }
                 return response.registerTokenResponse;
             }, tokenRequest, cancellationToken);
         }
@@ -586,7 +686,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, tokenRequest);
             var tokenResponse = cnpResponse.registerTokenResponse;
-            tokenResponse.location = cnpResponse.location;
+            if (tokenResponse != null)
+            {
+                tokenResponse.location = cnpResponse.location;
+            }
             return tokenResponse;
         }
 
@@ -594,16 +697,23 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, v);
             var voidResponse = cnpResponse.voidResponse;
-            voidResponse.location = cnpResponse.location;
+            if (voidResponse != null)
+            {
+                voidResponse.location = cnpResponse.location;
+            }
             return voidResponse;
         }
 
         public Task<voidResponse> DoVoidAsync(voidTxn v, CancellationToken cancellationToken)
         {
             return SendRequestAsync(response =>
-            {
-                response.voidResponse.location = response.location;
-                return response.voidResponse;
+            { 
+                var voidResponse = response.voidResponse;
+                if (voidResponse != null)
+                {
+                    voidResponse.location = response.location;
+                }
+                return voidResponse;
             }, v, cancellationToken);
         }
 
@@ -611,7 +721,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, v);
             var eCheckVoidResponse = cnpResponse.echeckVoidResponse;
-            eCheckVoidResponse.location = cnpResponse.location;
+            if (eCheckVoidResponse != null)
+            {
+                eCheckVoidResponse.location = cnpResponse.location;
+            }
             return eCheckVoidResponse;
         }
 
@@ -619,8 +732,12 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.echeckVoidResponse.location = response.location;
-                return response.echeckVoidResponse;
+                var echeckVoidResponse = response.echeckVoidResponse;
+                if (echeckVoidResponse != null)
+                {
+                    echeckVoidResponse.location = response.location;
+                }
+                return echeckVoidResponse;
             }, v, cancellationToken);
         }
 
@@ -628,8 +745,12 @@ namespace Cnp.Sdk
         {
             return SendRequest(response =>
             {
-                response.updateCardValidationNumOnTokenResponse.location = response.location;
-                return response.updateCardValidationNumOnTokenResponse;
+                var updateCardValidationNumOnTokenResponse = response.updateCardValidationNumOnTokenResponse;
+                if (updateCardValidationNumOnTokenResponse != null)
+                {
+                    updateCardValidationNumOnTokenResponse.location = response.location;
+                }
+                return updateCardValidationNumOnTokenResponse;
             }, updateCardValidationNumOnToken);
         }
 
@@ -637,8 +758,12 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.updateCardValidationNumOnTokenResponse.location = response.location;
-                return response.updateCardValidationNumOnTokenResponse;
+                var updateCardValidationNumOnTokenResponse = response.updateCardValidationNumOnTokenResponse;
+                if (updateCardValidationNumOnTokenResponse != null)
+                {
+                    updateCardValidationNumOnTokenResponse.location = response.location;
+                }
+                return updateCardValidationNumOnTokenResponse;
             }, update, cancellationToken);
         }
 
@@ -646,7 +771,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, cancelSubscription);
             var cancelSubscriptionResponse = cnpResponse.cancelSubscriptionResponse;
-            cancelSubscriptionResponse.location = cnpResponse.location;
+            if (cancelSubscriptionResponse != null)
+            {
+                cancelSubscriptionResponse.location = cnpResponse.location;
+            }
             return cancelSubscriptionResponse;
         }
 
@@ -654,7 +782,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, updateSubscription);
             var updateSubscriptionResponse = cnpResponse.updateSubscriptionResponse;
-            updateSubscriptionResponse.location = cnpResponse.location;
+            if (updateSubscriptionResponse != null)
+            {
+                updateSubscriptionResponse.location = cnpResponse.location;
+            }
             return updateSubscriptionResponse;
         }
 
@@ -662,7 +793,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, activate);
             var activatationResponse = cnpResponse.activateResponse;
-            activatationResponse.location = cnpResponse.location;
+            if (activatationResponse != null)
+            {
+                activatationResponse.location = cnpResponse.location;
+            }
             return activatationResponse;
         }
 
@@ -670,7 +804,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, deactivate);
             var deactivationResponse = cnpResponse.deactivateResponse;
-            deactivationResponse.location = cnpResponse.location;
+            if (deactivationResponse != null)
+            {
+                deactivationResponse.location = cnpResponse.location;
+            }
             return deactivationResponse;
         }
 
@@ -678,7 +815,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, load);
             var loadResponse = cnpResponse.loadResponse;
-            loadResponse.location = cnpResponse.location;
+            if (loadResponse != null)
+            {
+                loadResponse.location = cnpResponse.location;
+            }
             return loadResponse;
         }
 
@@ -686,7 +826,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, unload);
             var unloadResponse = cnpResponse.unloadResponse;
-            unloadResponse.location = cnpResponse.location;
+            if (unloadResponse != null)
+            {
+                unloadResponse.location = cnpResponse.location;
+            }
             return unloadResponse;
         }
 
@@ -694,7 +837,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, balanceInquiry);
             var balanceInquiryResponse = cnpResponse.balanceInquiryResponse;
-            balanceInquiryResponse.location = cnpResponse.location;
+            if (balanceInquiryResponse != null)
+            {
+                balanceInquiryResponse.location = cnpResponse.location;
+            }
             return balanceInquiryResponse;
         }
 
@@ -702,8 +848,12 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.balanceInquiryResponse.location = response.location;
-                return response.balanceInquiryResponse;
+                var balanceInquiryResponse = response.balanceInquiryResponse;
+                if (balanceInquiryResponse != null)
+                {
+                    balanceInquiryResponse.location = response.location;
+                }
+                return balanceInquiryResponse;
             }, balanceInquiry, cancellationToken);
         }
 
@@ -711,7 +861,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, createPlan);
             var createPlanResponse = cnpResponse.createPlanResponse;
-            createPlanResponse.location = cnpResponse.location;
+            if (createPlanResponse != null)
+            {
+                createPlanResponse.location = cnpResponse.location;
+            }
             return createPlanResponse;
         }
 
@@ -719,7 +872,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, updatePlan);
             var updatePlanResponse = cnpResponse.updatePlanResponse;
-            updatePlanResponse.location = cnpResponse.location;
+            if (updatePlanResponse != null)
+            {
+                updatePlanResponse.location = cnpResponse.location;
+            }
             return updatePlanResponse;
         }
 
@@ -727,7 +883,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, refundReversal);
             var refundReversalResponse = cnpResponse.refundReversalResponse;
-            refundReversalResponse.location = cnpResponse.location;
+            if (refundReversalResponse != null)
+            {
+                refundReversalResponse.location = cnpResponse.location;
+            }
             return refundReversalResponse;
         }
 
@@ -735,7 +894,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, depositReversal);
             var depositReversalResponse = cnpResponse.depositReversalResponse;
-            depositReversalResponse.location = cnpResponse.location;
+            if (depositReversalResponse != null)
+            {
+                depositReversalResponse.location = cnpResponse.location;
+            }
             return depositReversalResponse;
         }
 
@@ -743,7 +905,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, activateReversal);
             var activateReversalResponse = cnpResponse.activateReversalResponse;
-            activateReversalResponse.location = cnpResponse.location;
+            if (activateReversalResponse != null)
+            {
+                activateReversalResponse.location = cnpResponse.location;
+            }
             return activateReversalResponse;
         }
 
@@ -751,7 +916,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, deactivateReversal);
             var deactivateReversalResponse = cnpResponse.deactivateReversalResponse;
-            deactivateReversalResponse.location = cnpResponse.location;
+            if (deactivateReversalResponse != null)
+            {
+                deactivateReversalResponse.location = cnpResponse.location;
+            }
             return deactivateReversalResponse;
         }
 
@@ -759,7 +927,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, loadReversal);
             var loadReversalResponse = cnpResponse.loadReversalResponse;
-            loadReversalResponse.location = cnpResponse.location;
+            if (loadReversalResponse != null)
+            {
+                loadReversalResponse.location = cnpResponse.location;
+            }
             return loadReversalResponse;
         }
 
@@ -767,7 +938,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, unloadReversal);
             var unloadReversalResponse = cnpResponse.unloadReversalResponse;
-            unloadReversalResponse.location = cnpResponse.location;
+            if (unloadReversalResponse != null)
+            {
+                unloadReversalResponse.location = cnpResponse.location;
+            }
             return unloadReversalResponse;
         }
 
@@ -777,7 +951,10 @@ namespace Cnp.Sdk
             {
                 var res = response.queryTransactionResponse ??
                         (transactionTypeWithReportGroup) response.queryTransactionUnavailableResponse;
-                res.location = response.location;
+                if (res != null)
+                {
+                    res.location = response.location;
+                }
                 return res;
             }, queryTransaction, cancellationToken);
         }
@@ -787,7 +964,10 @@ namespace Cnp.Sdk
             var cnpResponse = SendRequest(response => response, queryTransaction);
             var transactionResponse = cnpResponse.queryTransactionResponse ??
                                       (transactionTypeWithReportGroup) cnpResponse.queryTransactionUnavailableResponse;
-            transactionResponse.location = cnpResponse.location;
+            if (transactionResponse != null)
+            {
+                transactionResponse.location = cnpResponse.location;
+            }
             return transactionResponse;
         }
 
@@ -795,7 +975,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, fraudCheck);
             var fraudCheckResponse = cnpResponse.fraudCheckResponse;
-            fraudCheckResponse.location = cnpResponse.location;
+            if (fraudCheckResponse != null)
+            {
+                fraudCheckResponse.location = cnpResponse.location;
+            }
             return fraudCheckResponse;
         }
 
@@ -803,7 +986,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, fastAccessFunding);
             var fastAccessFundingResponse = cnpResponse.fastAccessFundingResponse;
-            fastAccessFundingResponse.location = cnpResponse.location;
+            if (fastAccessFundingResponse != null)
+            {
+                fastAccessFundingResponse.location = cnpResponse.location;
+            }
             return fastAccessFundingResponse;
         }
         
@@ -811,7 +997,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, payFacCredit);
             var payFacCreditResponse = cnpResponse.payFacCreditResponse;
-            payFacCreditResponse.location = cnpResponse.location;
+            if (payFacCreditResponse != null)
+            {
+                payFacCreditResponse.location = cnpResponse.location;
+            }
             return payFacCreditResponse;
         }
 
@@ -819,8 +1008,12 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.payFacCreditResponse.location = response.location;
-                return response.payFacCreditResponse;
+                var payFacCreditResponse = response.payFacCreditResponse;
+                if (payFacCreditResponse != null)
+                {
+                    payFacCreditResponse.location = response.location;
+                }
+                return payFacCreditResponse;
             }, payFacCredit, cancellationToken);
         }
 
@@ -828,7 +1021,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, payFacDebit);
             var payfacDebitResponse = cnpResponse.payFacDebitResponse;
-            payfacDebitResponse.location = cnpResponse.location;
+            if (payfacDebitResponse != null)
+            {
+                payfacDebitResponse.location = cnpResponse.location;
+            }
             return payfacDebitResponse;
         }
 
@@ -836,8 +1032,12 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.payFacDebitResponse.location = response.location;
-                return response.payFacDebitResponse;
+                var payFacDebitResponse  = response.payFacDebitResponse;
+                if (payFacDebitResponse != null)
+                {
+                    payFacDebitResponse.location = response.location;
+                }
+                return payFacDebitResponse;
             }, payFacDebit, cancellationToken);
         }
 
@@ -845,7 +1045,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, physicalCheckCredit);
             var physicalCheckCreditResponse = cnpResponse.physicalCheckCreditResponse;
-            physicalCheckCreditResponse.location = cnpResponse.location;
+            if (physicalCheckCreditResponse != null)
+            {
+                physicalCheckCreditResponse.location = cnpResponse.location;
+            }
             return physicalCheckCreditResponse;
         }
 
@@ -853,8 +1056,12 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.physicalCheckCreditResponse.location = response.location;
-                return response.physicalCheckCreditResponse;
+                var physicalCheckCreditResponse = response.physicalCheckCreditResponse;
+                if (physicalCheckCreditResponse != null)
+                {
+                    physicalCheckCreditResponse.location = response.location;
+                }
+                return physicalCheckCreditResponse;
             }, physicalCheckCredit, cancellationToken);
         }
 
@@ -862,7 +1069,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, physicalCheckDebit);
             var physicalCheckDebitResponse = cnpResponse.physicalCheckDebitResponse;
-            physicalCheckDebitResponse.location = cnpResponse.location;
+            if (physicalCheckDebitResponse != null)
+            {
+                physicalCheckDebitResponse.location = cnpResponse.location;
+            }
             return physicalCheckDebitResponse;
         }
 
@@ -870,8 +1080,12 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.physicalCheckDebitResponse.location = response.location;
-                return response.physicalCheckDebitResponse;
+                var physicalCheckDebitResponse = response.physicalCheckDebitResponse;
+                if (physicalCheckDebitResponse != null)
+                {
+                    physicalCheckDebitResponse.location = response.location;
+                }
+                return physicalCheckDebitResponse;
             }, physicalCheckDebit, cancellationToken);
         }
 
@@ -879,7 +1093,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, payoutOrgCredit);
             var payoutOrgCreditResponse = cnpResponse.payoutOrgCreditResponse;
-            payoutOrgCreditResponse.location = cnpResponse.location;
+            if (payoutOrgCreditResponse != null)
+            {
+                payoutOrgCreditResponse.location = cnpResponse.location;
+            }
             return payoutOrgCreditResponse;
         }
 
@@ -887,8 +1104,12 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.payoutOrgCreditResponse.location = response.location;
-                return response.payoutOrgCreditResponse;
+                var payoutOrgCreditResponse = response.payoutOrgCreditResponse;
+                if (payoutOrgCreditResponse != null)
+                {
+                    payoutOrgCreditResponse.location = response.location;
+                }
+                return payoutOrgCreditResponse;
             }, payoutOrgCredit, cancellationToken);
         }
 
@@ -896,7 +1117,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, payoutOrgDebit);
             var payoutOrgDebitResponse = cnpResponse.payoutOrgDebitResponse;
-            payoutOrgDebitResponse.location = cnpResponse.location;
+            if (payoutOrgDebitResponse != null)
+            {
+                payoutOrgDebitResponse.location = cnpResponse.location;
+            }
             return payoutOrgDebitResponse;
         }
 
@@ -904,8 +1128,12 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.payoutOrgDebitResponse.location = response.location;
-                return response.payoutOrgDebitResponse;
+                var payoutOrgDebitResponse = response.payoutOrgDebitResponse;
+                if (payoutOrgDebitResponse != null)
+                {
+                    payoutOrgDebitResponse.location = response.location;
+                }
+                return payoutOrgDebitResponse;
             }, payoutOrgDebit, cancellationToken);
         }
 
@@ -913,7 +1141,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, reserveCredit);
             var reserveCreditResponse = cnpResponse.reserveCreditResponse;
-            reserveCreditResponse.location = cnpResponse.location;
+            if (reserveCreditResponse != null)
+            {
+                reserveCreditResponse.location = cnpResponse.location;
+            }
             return reserveCreditResponse;
         }
 
@@ -921,7 +1152,11 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.reserveCreditResponse.location = response.location;
+                var reserveCreditResponse = response.reserveCreditResponse;
+                if (reserveCreditResponse != null)
+                {
+                    reserveCreditResponse.location = response.location;
+                }
                 return response.reserveCreditResponse;
             }, reserveCredit, cancellationToken);
         }
@@ -930,7 +1165,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, reserveDebit);
             var reserveDebitResponse = cnpResponse.reserveDebitResponse;
-            reserveDebitResponse.location = cnpResponse.location;
+            if (reserveDebitResponse != null)
+            {
+                reserveDebitResponse.location = cnpResponse.location;
+            }
             return reserveDebitResponse;
         }
 
@@ -938,8 +1176,12 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.reserveDebitResponse.location = response.location;
-                return response.reserveDebitResponse;
+                var reserveDebitResponse = response.reserveDebitResponse;
+                if (reserveDebitResponse != null)
+                {
+                    reserveDebitResponse.location = response.location;
+                }
+                return reserveDebitResponse;
             }, reserveDebit, cancellationToken);
         }
 
@@ -947,7 +1189,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, submerchantCredit);
             var submerchantCreditResponse = cnpResponse.submerchantCreditResponse;
-            submerchantCreditResponse.location = cnpResponse.location;
+            if (submerchantCreditResponse != null)
+            {
+                submerchantCreditResponse.location = cnpResponse.location;
+            }
             return submerchantCreditResponse;
         }
 
@@ -955,8 +1200,12 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.submerchantCreditResponse.location = response.location;
-                return response.submerchantCreditResponse;
+                var submerchantCreditResponse = response.submerchantCreditResponse;
+                if (submerchantCreditResponse != null)
+                {
+                    submerchantCreditResponse.location = response.location;
+                }
+                return submerchantCreditResponse;
             }, submerchantCredit, cancellationToken);
         }
 
@@ -964,7 +1213,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, submerchantDebit);
             var submerchantDebitResponse = cnpResponse.submerchantDebitResponse;
-            submerchantDebitResponse.location = cnpResponse.location;
+            if (submerchantDebitResponse != null)
+            {
+                submerchantDebitResponse.location = cnpResponse.location;
+            }
             return submerchantDebitResponse;
         }
 
@@ -972,8 +1224,12 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.submerchantDebitResponse.location = response.location;
-                return response.submerchantDebitResponse;
+                var submerchantDebitResponse = response.submerchantDebitResponse;
+                if (submerchantDebitResponse != null)
+                {
+                    submerchantDebitResponse.location = response.location;
+                }
+                return submerchantDebitResponse;
             }, submerchantDebit, cancellationToken);
         }
 
@@ -981,7 +1237,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, vendorCredit);
             var vendorCreditResponse = cnpResponse.vendorCreditResponse;
-            vendorCreditResponse.location = cnpResponse.location;
+            if (vendorCreditResponse != null)
+            {
+                vendorCreditResponse.location = cnpResponse.location;
+            }
             return vendorCreditResponse;
         }
 
@@ -989,8 +1248,12 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.vendorCreditResponse.location = response.location;
-                return response.vendorCreditResponse;
+                var vendorCreditResponse = response.vendorCreditResponse;
+                if (vendorCreditResponse != null)
+                {
+                    vendorCreditResponse.location = response.location;
+                }
+                return vendorCreditResponse;
             }, vendorCredit, cancellationToken);
         }
 
@@ -998,7 +1261,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, customerCredit);
             var customerCreditResponse = cnpResponse.customerCreditResponse;
-            customerCreditResponse.location = cnpResponse.location;
+            if (customerCreditResponse != null)
+            {
+                customerCreditResponse.location = cnpResponse.location;
+            }
             return customerCreditResponse;
         }
 
@@ -1006,8 +1272,12 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.customerCreditResponse.location = response.location;
-                return response.customerCreditResponse;
+                var customerCreditResponse = response.customerCreditResponse;
+                if (customerCreditResponse != null)
+                {
+                    customerCreditResponse.location = response.location;
+                }
+                return customerCreditResponse;
             }, customerCredit, cancellationToken);
         }
 
@@ -1015,7 +1285,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, translateToLowValueTokenRequest);
             var translateToLowValueTokenResponse = cnpResponse.translateToLowValueTokenResponse;
-            translateToLowValueTokenResponse.location = cnpResponse.location;
+            if (translateToLowValueTokenResponse != null)
+            {
+                translateToLowValueTokenResponse.location = cnpResponse.location;
+            }
             return translateToLowValueTokenResponse;
         }
 
@@ -1023,8 +1296,12 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.translateToLowValueTokenResponse.location = response.location;
-                return response.translateToLowValueTokenResponse;
+                var translateToLowValueTokenResponse = response.translateToLowValueTokenResponse;
+                if (translateToLowValueTokenResponse != null)
+                {
+                    translateToLowValueTokenResponse.location = response.location;
+                }
+                return translateToLowValueTokenResponse;
             }, translateToLowValueTokenRequest, cancellationToken);
         }
 
@@ -1032,7 +1309,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, vendorDebit);
             var vendorDebitResponse = cnpResponse.vendorDebitResponse;
-            vendorDebitResponse.location = cnpResponse.location;
+            if (vendorDebitResponse != null)
+            {
+                vendorDebitResponse.location = cnpResponse.location;
+            }
             return vendorDebitResponse;
         }
 
@@ -1040,8 +1320,12 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.vendorDebitResponse.location = response.location;
-                return response.vendorDebitResponse;
+                var vendorDebitResponse = response.vendorDebitResponse;
+                if (vendorDebitResponse != null)
+                {
+                    vendorDebitResponse.location = response.location;
+                }
+                return vendorDebitResponse;
             }, vendorDebit, cancellationToken);
         }
 
@@ -1049,7 +1333,10 @@ namespace Cnp.Sdk
         {
             var cnpResponse = SendRequest(response => response, customerDebit);
             var customerDebitResponse = cnpResponse.customerDebitResponse;
-            customerDebitResponse.location = cnpResponse.location;
+            if (customerDebitResponse != null)
+            {
+                customerDebitResponse.location = cnpResponse.location;
+            }
             return customerDebitResponse;
         }
 
@@ -1057,8 +1344,12 @@ namespace Cnp.Sdk
         {
             return SendRequestAsync(response =>
             {
-                response.customerDebitResponse.location = response.location;
-                return response.customerDebitResponse;
+                var customerDebitResponse = response.customerDebitResponse;
+                if (customerDebitResponse != null)
+                {
+                    customerDebitResponse.location = response.location;
+                }
+                return customerDebitResponse;
             }, customerDebit, cancellationToken);
         }
 

--- a/CnpSdkForNet/CnpSdkForNet/CnpOnline.cs
+++ b/CnpSdkForNet/CnpSdkForNet/CnpOnline.cs
@@ -76,7 +76,15 @@ namespace Cnp.Sdk
 
         public Task<authorizationResponse> AuthorizeAsync(authorization auth, CancellationToken cancellationToken)
         {
-            return SendRequestAsync(response => response.authorizationResponse, auth, cancellationToken);
+            return SendRequestAsync(response =>
+            {
+                var authResponse = response.authorizationResponse;
+                if (authResponse != null)
+                {
+                    authResponse.location = response.location;
+                }
+                return authResponse;
+            }, auth, cancellationToken);
         }
 
         private T SendRequest<T>(Func<cnpOnlineResponse, T> getResponse, transactionRequest transaction)

--- a/CnpSdkForNet/CnpSdkForNet/CnpSdkForNet.csproj
+++ b/CnpSdkForNet/CnpSdkForNet/CnpSdkForNet.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>dotNetSDKKey.snk</AssemblyOriginatorKeyFile>
-        <PackageVersion>12.11.0</PackageVersion>
+        <PackageVersion>12.12.0</PackageVersion>
         <Title>Vantiv.CnpSdkForNet</Title>
         <Authors>Worldpay</Authors>
         <Copyright>Copyright © Worldpay 2019</Copyright>

--- a/CnpSdkForNet/CnpSdkForNet/CnpVersion.cs
+++ b/CnpSdkForNet/CnpSdkForNet/CnpVersion.cs
@@ -8,7 +8,7 @@ namespace Cnp.Sdk
      */
     public class CnpVersion
     {
-        public const String CurrentCNPXMLVersion = "12.11";
-        public const String CurrentCNPSDKVersion = "12.11.0";
+        public const String CurrentCNPXMLVersion = "12.12";
+        public const String CurrentCNPSDKVersion = "12.12.0";
     }
 }

--- a/CnpSdkForNet/CnpSdkForNet/XmlResponseFields.cs
+++ b/CnpSdkForNet/CnpSdkForNet/XmlResponseFields.cs
@@ -38,6 +38,8 @@ namespace Cnp.Sdk
     {
 
         private string reportGroupField;
+        
+        private string locationField;
 
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
@@ -50,6 +52,18 @@ namespace Cnp.Sdk
             set
             {
                 this.reportGroupField = value;
+            }
+        }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
             }
         }
     }
@@ -217,6 +231,20 @@ namespace Cnp.Sdk
             set
             {
                 this.responseTimeField = value;
+            }
+        }
+
+        private string locationField;
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
             }
         }
     }
@@ -7178,6 +7206,7 @@ namespace Cnp.Sdk
         public DateTime postDate;
         public fraudResult fraudResult;
         public giftCardResponse giftCardResponse;
+        private string locationField;
 
         /// <remarks/>
         public long cnpTxnId
@@ -7189,6 +7218,18 @@ namespace Cnp.Sdk
             set
             {
                 this.cnpTxnIdField = value;
+            }
+        }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
             }
         }
     }
@@ -7209,6 +7250,7 @@ namespace Cnp.Sdk
         public string message;
         public fraudResult fraudResult;
         public giftCardResponse giftCardResponse;
+        private string locationField;
 
         /// <remarks/>
         public long cnpTxnId
@@ -7220,6 +7262,18 @@ namespace Cnp.Sdk
             set
             {
                 this.cnpTxnIdField = value;
+            }
+        }
+
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
             }
         }
     }
@@ -7239,6 +7293,7 @@ namespace Cnp.Sdk
         public string message;
         public fraudResult fraudResult;
         public giftCardResponse giftCardResponse;
+        private string locationField;
 
         /// <remarks/>
         public long cnpTxnId
@@ -7250,6 +7305,18 @@ namespace Cnp.Sdk
             set
             {
                 this.cnpTxnIdField = value;
+            }
+        }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
             }
         }
     }
@@ -7269,6 +7336,7 @@ namespace Cnp.Sdk
         public string message;
         public fraudResult fraudResult;
         public giftCardResponse giftCardResponse;
+        private string locationField;
 
         /// <remarks/>
         public long cnpTxnId
@@ -7280,6 +7348,18 @@ namespace Cnp.Sdk
             set
             {
                 this.cnpTxnIdField = value;
+            }
+        }
+
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
             }
         }
     }
@@ -7328,6 +7408,8 @@ namespace Cnp.Sdk
         private string messageField;
         
         private giftCardResponse giftCardResponseField;
+        
+        private string locationField;
         
         /// <remarks/>
         public long cnpTxnId {
@@ -7400,6 +7482,18 @@ namespace Cnp.Sdk
                 this.giftCardResponseField = value;
             }
         }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
+            }
+        }
     }
 
 
@@ -7418,6 +7512,7 @@ namespace Cnp.Sdk
         public string message;
         public fraudResult fraudResult;
         public giftCardResponse giftCardResponse;
+        private string locationField;
 
         /// <remarks/>
         public long cnpTxnId
@@ -7429,6 +7524,18 @@ namespace Cnp.Sdk
             set
             {
                 this.cnpTxnIdField = value;
+            }
+        }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
             }
         }
     }
@@ -7448,6 +7555,7 @@ namespace Cnp.Sdk
         public string message;
         public fraudResult fraudResult;
         public giftCardResponse giftCardResponse;
+        private string locationField;
 
         /// <remarks/>
         public long cnpTxnId
@@ -7459,6 +7567,18 @@ namespace Cnp.Sdk
             set
             {
                 this.cnpTxnIdField = value;
+            }
+        }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
             }
         }
     }
@@ -7478,6 +7598,7 @@ namespace Cnp.Sdk
         public string message;
         public fraudResult fraudResult;
         public giftCardResponse giftCardResponse;
+        private string locationField;
 
         /// <remarks/>
         public long cnpTxnId
@@ -7489,6 +7610,18 @@ namespace Cnp.Sdk
             set
             {
                 this.cnpTxnIdField = value;
+            }
+        }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
             }
         }
     }
@@ -7508,6 +7641,7 @@ namespace Cnp.Sdk
         public string message;
         public fraudResult fraudResult;
         public giftCardResponse giftCardResponse;
+        private string locationField;
 
         /// <remarks/>
         public long cnpTxnId
@@ -7519,6 +7653,18 @@ namespace Cnp.Sdk
             set
             {
                 this.cnpTxnIdField = value;
+            }
+        }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
             }
         }
     }
@@ -7538,6 +7684,7 @@ namespace Cnp.Sdk
         public string message;
         public fraudResult fraudResult;
         public giftCardResponse giftCardResponse;
+        private string locationField;
 
         /// <remarks/>
         public long cnpTxnId
@@ -7549,6 +7696,18 @@ namespace Cnp.Sdk
             set
             {
                 this.cnpTxnIdField = value;
+            }
+        }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
             }
         }
     }
@@ -7988,6 +8147,8 @@ namespace Cnp.Sdk
 
         private advancedFraudResultsType advancedFraudResultsField;
 
+        private string locationField;
+
         /// <remarks/>
         public long cnpTxnId
         {
@@ -8052,6 +8213,18 @@ namespace Cnp.Sdk
                 this.advancedFraudResultsField = value;
             }
         }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
+            }
+        }
     }
 
     /// <remarks/>
@@ -8077,6 +8250,8 @@ namespace Cnp.Sdk
         private bool postDateFieldSpecified;
 
         private string messageField;
+
+        private string locationField;
 
         private bool duplicateField;
 
@@ -8172,6 +8347,18 @@ namespace Cnp.Sdk
             set
             {
                 this.messageField = value;
+            }
+        }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
             }
         }
 
@@ -8224,6 +8411,8 @@ namespace Cnp.Sdk
 
         private string messageField;
 
+        private string locationField;
+
         /// <remarks/>
         public long cnpTxnId
         {
@@ -8288,6 +8477,18 @@ namespace Cnp.Sdk
                 this.messageField = value;
             }
         }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
+            }
+        }
     }
 
     /// <remarks/>
@@ -8313,6 +8514,8 @@ namespace Cnp.Sdk
         private bool postDateFieldSpecified;
 
         private string messageField;
+
+        private string locationField;
 
         private bool duplicateField;
 
@@ -8408,6 +8611,18 @@ namespace Cnp.Sdk
             set
             {
                 this.messageField = value;
+            }
+        }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
             }
         }
 
@@ -8464,6 +8679,8 @@ namespace Cnp.Sdk
 
         private string messageField;
 
+        private string locationField;
+
         private bool duplicateField;
 
         private bool duplicateFieldSpecified;
@@ -8558,6 +8775,18 @@ namespace Cnp.Sdk
             set
             {
                 this.messageField = value;
+            }
+        }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
             }
         }
 
@@ -8609,6 +8838,8 @@ namespace Cnp.Sdk
     
     private string messageField;
     
+    private string locationField;
+    
     /// <remarks/>
     public long cnpTxnId {
         get {
@@ -8658,6 +8889,18 @@ namespace Cnp.Sdk
             this.messageField = value;
         }
     }
+    
+    public string location
+    {
+        get
+        {
+            return this.locationField;
+        }
+        set
+        {
+            this.locationField = value;
+        }
+    }
 }
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "2.0.50727.3038")]
@@ -8678,6 +8921,8 @@ namespace Cnp.Sdk
         private System.DateTime responseTimeField;
 
         private string messageField;
+
+        private string locationField;
 
         private bool duplicateField;
 
@@ -8747,6 +8992,18 @@ namespace Cnp.Sdk
                 this.messageField = value;
             }
         }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
+            }
+        }
 
         public bool duplicate
         {
@@ -8792,6 +9049,8 @@ namespace Cnp.Sdk
         private System.DateTime responseTimeField;
 
         private string messageField;
+        
+        private string locationField;
 
         /// <remarks/>
         public long cnpTxnId
@@ -8857,6 +9116,18 @@ namespace Cnp.Sdk
                 this.messageField = value;
             }
         }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
+            }
+        }
     }
 
     /// <remarks/>
@@ -8882,6 +9153,8 @@ namespace Cnp.Sdk
         private bool postDateFieldSpecified;
 
         private string messageField;
+
+        private string locationField;
 
         private bool duplicateField;
 
@@ -8977,6 +9250,18 @@ namespace Cnp.Sdk
             set
             {
                 this.messageField = value;
+            }
+        }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
             }
         }
 
@@ -9029,6 +9314,8 @@ namespace Cnp.Sdk
 
         private string messageField;
 
+        private string locationField;
+
         /// <remarks/>
         public long cnpTxnId
         {
@@ -9093,6 +9380,18 @@ namespace Cnp.Sdk
                 this.messageField = value;
             }
         }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
+            }
+        }
     }
 
     /// <remarks/>
@@ -9118,6 +9417,8 @@ namespace Cnp.Sdk
         private bool postDateFieldSpecified;
 
         private string messageField;
+
+        private string locationField;
 
         private bool duplicateField;
 
@@ -9213,6 +9514,18 @@ namespace Cnp.Sdk
             set
             {
                 this.messageField = value;
+            }
+        }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
             }
         }
 
@@ -9269,6 +9582,8 @@ namespace Cnp.Sdk
 
         private string messageField;
 
+        private string locationField;
+
         private bool duplicateField;
 
         private bool duplicateFieldSpecified;
@@ -9365,6 +9680,18 @@ namespace Cnp.Sdk
                 this.messageField = value;
             }
         }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
+            }
+        }
 
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
@@ -9414,6 +9741,8 @@ namespace Cnp.Sdk
         private System.DateTime responseTimeField;
 
         private string messageField;
+
+        private string locationField;
 
         /// <remarks/>
         public long cnpTxnId
@@ -9479,6 +9808,18 @@ namespace Cnp.Sdk
                 this.messageField = value;
             }
         }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
+            }
+        }
     }
 
     /// <remarks/>
@@ -9500,6 +9841,8 @@ namespace Cnp.Sdk
         private System.DateTime responseTimeField;
 
         private string messageField;
+
+        private string locationField;
 
         private bool duplicateField;
 
@@ -9569,6 +9912,18 @@ namespace Cnp.Sdk
                 this.messageField = value;
             }
         }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
+            }
+        }
 
         public bool duplicate
         {
@@ -9614,6 +9969,8 @@ namespace Cnp.Sdk
         private System.DateTime responseTimeField;
 
         private string messageField;
+
+        private string locationField;
 
         /// <remarks/>
         public long cnpTxnId
@@ -9677,6 +10034,18 @@ namespace Cnp.Sdk
             set
             {
                 this.messageField = value;
+            }
+        }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
             }
         }
     }
@@ -9773,7 +10142,7 @@ namespace Cnp.Sdk
         private string matchCountField;
 
         private ArrayList results_max10Field;
-
+        
         /// <remarks/>
         public string matchCount
         {
@@ -9825,8 +10194,8 @@ namespace Cnp.Sdk
                 this.messageField = value;
             }
         }
-        
-                /// <remarks/>
+
+        /// <remarks/>
         [XmlArray("results_max10")]
         [XmlArrayItem("authorizationResponse", typeof(authorizationResponse))]
         [XmlArrayItem("captureResponse", typeof(captureResponse))]
@@ -9899,6 +10268,8 @@ namespace Cnp.Sdk
         private string messageField;
         
         private tokenResponseType tokenResponseField;
+
+        private string locationField;
         
         private bool duplicateField;
         
@@ -9983,6 +10354,18 @@ namespace Cnp.Sdk
             }
             set {
                 this.tokenResponseField = value;
+            }
+        }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
             }
         }
         
@@ -10409,6 +10792,8 @@ namespace Cnp.Sdk
 
         private string messageField;
 
+        private string locationField;
+
         private System.DateTime responseTimeField;
 
         /// <remarks/>
@@ -10460,6 +10845,18 @@ namespace Cnp.Sdk
             set
             {
                 this.messageField = value;
+            }
+        }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
             }
         }
 

--- a/CnpSdkForNet/CnpSdkForNet/XmlResponseFields.cs
+++ b/CnpSdkForNet/CnpSdkForNet/XmlResponseFields.cs
@@ -4936,6 +4936,8 @@ namespace Cnp.Sdk
 
         private string versionField;
 
+        private string locationField;
+
         public authReversalResponse authReversalResponse;
         public giftCardAuthReversalResponse giftCardAuthReversalResponse;
         public authorizationResponse authorizationResponse;
@@ -5028,6 +5030,20 @@ namespace Cnp.Sdk
             set
             {
                 this.versionField = value;
+            }
+        }
+
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
             }
         }
     }

--- a/CnpSdkForNet/CnpSdkForNet/XmlResponseFields.cs
+++ b/CnpSdkForNet/CnpSdkForNet/XmlResponseFields.cs
@@ -55,6 +55,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -236,6 +237,7 @@ namespace Cnp.Sdk
 
         private string locationField;
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -1858,6 +1860,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -1996,6 +1999,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -2397,6 +2401,7 @@ namespace Cnp.Sdk
             }
         }
 
+        //TODO: make deserializable
         public string location
         {
             get
@@ -2487,6 +2492,7 @@ namespace Cnp.Sdk
 
         private string locationField;
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -2557,6 +2563,7 @@ namespace Cnp.Sdk
         
         private string locationField;
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -3058,6 +3065,7 @@ namespace Cnp.Sdk
             }
         }
 
+        //TODO: make deserializable
         public string location
         {
             get
@@ -3187,6 +3195,7 @@ namespace Cnp.Sdk
             }
         }
 
+        //TODO: make deserializable
         public string location
         {
             get { return this.locationField; }
@@ -3308,6 +3317,7 @@ namespace Cnp.Sdk
             }
         }
 
+        //TODO: make deserializable
         public string location
         {
             get
@@ -3458,9 +3468,13 @@ namespace Cnp.Sdk
             }
         }
 
+        //TODO: make deserializable
         public string location
         {
-            get { return this.locationField; }
+            get
+            {
+                return this.locationField;
+            }
             set
             {
                 this.locationField = value;
@@ -3618,6 +3632,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -3777,6 +3792,7 @@ namespace Cnp.Sdk
             }
         }
 
+        //TODO: make deserializable
         public string location
         {
             get
@@ -3972,6 +3988,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -4399,6 +4416,7 @@ namespace Cnp.Sdk
             }
         }
 
+        //TODO: make deserializable
         public string location
         {
             get
@@ -4548,6 +4566,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -4681,6 +4700,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -4841,6 +4861,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -4986,6 +5007,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -5120,6 +5142,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -6980,6 +7003,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -7086,6 +7110,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -7161,6 +7186,7 @@ namespace Cnp.Sdk
         public virtualGiftCardResponseType virtualGiftCardResponse;
         private string locationField;
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -7221,6 +7247,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -7265,6 +7292,7 @@ namespace Cnp.Sdk
             }
         }
 
+        //TODO: make deserializable
         public string location
         {
             get
@@ -7308,6 +7336,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -7351,6 +7380,7 @@ namespace Cnp.Sdk
             }
         }
 
+        //TODO: make deserializable
         public string location
         {
             get
@@ -7483,6 +7513,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -7527,6 +7558,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -7570,6 +7602,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -7613,6 +7646,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -7656,6 +7690,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -7699,6 +7734,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -8214,6 +8250,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -8350,6 +8387,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -8478,6 +8516,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -8614,6 +8653,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -8778,6 +8818,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -8890,6 +8931,7 @@ namespace Cnp.Sdk
         }
     }
     
+    //TODO: make deserializable
     public string location
     {
         get
@@ -8993,6 +9035,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -9117,6 +9160,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -9253,6 +9297,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -9381,6 +9426,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -9517,6 +9563,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -9681,6 +9728,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -9809,6 +9857,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -9913,6 +9962,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -10037,6 +10087,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -10357,6 +10408,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get
@@ -10848,6 +10900,7 @@ namespace Cnp.Sdk
             }
         }
         
+        //TODO: make deserializable
         public string location
         {
             get

--- a/CnpSdkForNet/CnpSdkForNet/XmlResponseFields.cs
+++ b/CnpSdkForNet/CnpSdkForNet/XmlResponseFields.cs
@@ -1711,6 +1711,8 @@ namespace Cnp.Sdk
         private string responseField;
 
         private string messageField;
+        
+        private string locationField;
 
         private System.DateTime responseTimeField;
 
@@ -1827,6 +1829,18 @@ namespace Cnp.Sdk
                 this.messageField = value;
             }
         }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
+            }
+        }
 
         /// <remarks/>
         public System.DateTime responseTime
@@ -1910,6 +1924,8 @@ namespace Cnp.Sdk
         private string responseField;
 
         private string messageField;
+        
+        private string locationField;
 
         private System.DateTime responseTimeField;
 
@@ -1949,6 +1965,18 @@ namespace Cnp.Sdk
             set
             {
                 this.messageField = value;
+            }
+        }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
             }
         }
 
@@ -2023,6 +2051,8 @@ namespace Cnp.Sdk
         private androidpayResponse androidpayResponseField;
 
         private string networkTransactionIdField;
+
+        private string locationField;
 
         private string paymentAccountReferenceNumberField;
 
@@ -2339,6 +2369,18 @@ namespace Cnp.Sdk
             }
         }
 
+        public string location
+        {
+            get
+            {
+                return locationField;
+            }
+            set
+            {
+                this.locationField = value;
+            }
+        }
+
         public string paymentAccountReferenceNumber
         {
             get { return paymentAccountReferenceNumberField; }
@@ -2415,6 +2457,20 @@ namespace Cnp.Sdk
             }
         }
 
+        private string locationField;
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
+            }
+        }
+
         private System.DateTime responseTimeField;
 
         /// <remarks/>
@@ -2469,6 +2525,20 @@ namespace Cnp.Sdk
         public string message {
             get { return this.messageField; }
             set { this.messageField = value; }
+        }
+        
+        private string locationField;
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
+            }
         }
 
         private System.DateTime responseTimeField;
@@ -2878,6 +2948,8 @@ namespace Cnp.Sdk
 
         private string messageField;
 
+        private string locationField;
+
         /// <remarks/>
         public long cnpTxnId
         {
@@ -2958,6 +3030,14 @@ namespace Cnp.Sdk
             }
         }
 
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set { this.locationField = value; }
+        }
     }
 
     /// <remarks/>
@@ -2983,6 +3063,8 @@ namespace Cnp.Sdk
         private string messageField;
 
         private giftCardResponse giftCardResponseField;
+
+        private string locationField;
 
 
         /// <remarks/>
@@ -3077,6 +3159,12 @@ namespace Cnp.Sdk
             }
         }
 
+        public string location
+        {
+            get { return this.locationField; }
+            set { this.locationField = value; }
+        }
+
 
     }
 
@@ -3105,6 +3193,8 @@ namespace Cnp.Sdk
         private bool postDateFieldSpecified;
 
         private string messageField;
+
+        private string locationField;
 
         private accountUpdater accountUpdaterField;
 
@@ -3190,6 +3280,18 @@ namespace Cnp.Sdk
             }
         }
 
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
+            }
+        }
+
         /// <remarks/>
         public accountUpdater accountUpdater
         {
@@ -3239,6 +3341,8 @@ namespace Cnp.Sdk
         private bool postDateFieldSpecified;
 
         private string messageField;
+
+        private string locationField;
 
         private accountUpdater accountUpdaterField;
 
@@ -3326,6 +3430,15 @@ namespace Cnp.Sdk
             }
         }
 
+        public string location
+        {
+            get { return this.locationField; }
+            set
+            {
+                this.locationField = value;
+            }
+        }
+
         /// <remarks/>
         public accountUpdater accountUpdater
         {
@@ -3390,6 +3503,8 @@ namespace Cnp.Sdk
         private bool postDateFieldSpecified;
 
         private string messageField;
+        
+        private string locationField;
 
         private tokenResponseType tokenResponseField;
 
@@ -3474,6 +3589,18 @@ namespace Cnp.Sdk
                 this.messageField = value;
             }
         }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
+            }
+        }
 
         /// <remarks/>
         public tokenResponseType tokenResponse
@@ -3526,6 +3653,8 @@ namespace Cnp.Sdk
         private string messageField;
 
         private tokenResponseType tokenResponseField;
+
+        private string locationField;
 
         /// <remarks/>
         public long cnpTxnId
@@ -3619,6 +3748,18 @@ namespace Cnp.Sdk
                 this.tokenResponseField = value;
             }
         }
+
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
+            }
+        }
     }
 
     /// <remarks/>
@@ -3646,6 +3787,8 @@ namespace Cnp.Sdk
         private bool postDateFieldSpecified;
 
         private string messageField;
+
+        private string locationField;
 
         private String cardSuffixField;
 
@@ -3798,6 +3941,18 @@ namespace Cnp.Sdk
             set
             {
                 this.messageField = value;
+            }
+        }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
             }
         }
 
@@ -4129,6 +4284,8 @@ namespace Cnp.Sdk
 
         private string messageField;
 
+        private string locationField;
+
         private tokenResponseType tokenResponseField;
 
         private fraudResult fraudResultField;
@@ -4214,6 +4371,18 @@ namespace Cnp.Sdk
             }
         }
 
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
+            }
+        }
+
         /// <remarks/>
         public tokenResponseType tokenResponse
         {
@@ -4261,6 +4430,8 @@ namespace Cnp.Sdk
         private bool postDateFieldSpecified;
 
         private string messageField;
+        
+        private string locationField;
 
         private tokenResponseType tokenResponseField;
 
@@ -4348,6 +4519,18 @@ namespace Cnp.Sdk
                 this.messageField = value;
             }
         }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
+            }
+        }
 
         /// <remarks/>
         public tokenResponseType tokenResponse
@@ -4405,6 +4588,8 @@ namespace Cnp.Sdk
         private System.DateTime responseTimeField;
 
         private string messageField;
+        
+        private string locationField;
 
         private string verificationCodeField;
 
@@ -4465,6 +4650,18 @@ namespace Cnp.Sdk
             set
             {
                 this.messageField = value;
+            }
+        }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
             }
         }
 
@@ -4554,6 +4751,8 @@ namespace Cnp.Sdk
 
         private string messageField;
 
+        private string locationField;
+
         private System.DateTime postDateField;
 
         private bool postDateFieldSpecified;
@@ -4611,6 +4810,18 @@ namespace Cnp.Sdk
             set
             {
                 this.messageField = value;
+            }
+        }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
             }
         }
 
@@ -4687,6 +4898,8 @@ namespace Cnp.Sdk
 
         private string messageField;
 
+        private string locationField;
+
         private System.DateTime postDateField;
 
         private bool postDateFieldSpecified;
@@ -4742,6 +4955,18 @@ namespace Cnp.Sdk
             set
             {
                 this.messageField = value;
+            }
+        }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
             }
         }
 
@@ -4804,6 +5029,8 @@ namespace Cnp.Sdk
         private System.DateTime responseTimeField;
 
         private string messageField;
+        
+        private string locationField;
 
         private System.DateTime postDateField;
 
@@ -4862,6 +5089,18 @@ namespace Cnp.Sdk
             set
             {
                 this.messageField = value;
+            }
+        }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
             }
         }
 
@@ -4935,9 +5174,9 @@ namespace Cnp.Sdk
         private string messageField;
 
         private string versionField;
-
+        
         private string locationField;
-
+        
         public authReversalResponse authReversalResponse;
         public giftCardAuthReversalResponse giftCardAuthReversalResponse;
         public authorizationResponse authorizationResponse;
@@ -5037,14 +5276,8 @@ namespace Cnp.Sdk
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public string location
         {
-            get
-            {
-                return this.locationField;
-            }
-            set
-            {
-                this.locationField = value;
-            }
+            get { return this.locationField; }
+            set { this.locationField = value;  }
         }
     }
 
@@ -6651,6 +6884,8 @@ namespace Cnp.Sdk
 
         private string messageField;
 
+        private string locationField;
+        
         /// <remarks/>
         public long cnpTxnId
         {
@@ -6716,6 +6951,18 @@ namespace Cnp.Sdk
                 this.messageField = value;
             }
         }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
+            }
+        }
 
     }
 
@@ -6738,6 +6985,8 @@ namespace Cnp.Sdk
         private System.DateTime postDateField;
 
         private string messageField;
+
+        private string locationField;
 
         private voidRecyclingResponseType recyclingResponseField;
 
@@ -6766,6 +7015,8 @@ namespace Cnp.Sdk
                 this.responseField = value;
             }
         }
+        
+        
 
         /// <remarks/>
         public System.DateTime responseTime
@@ -6804,6 +7055,18 @@ namespace Cnp.Sdk
             set
             {
                 this.messageField = value;
+            }
+        }
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
             }
         }
 
@@ -6868,6 +7131,19 @@ namespace Cnp.Sdk
         public fraudResult fraudResult;
         public giftCardResponse giftCardResponse;
         public virtualGiftCardResponseType virtualGiftCardResponse;
+        private string locationField;
+        
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set
+            {
+                this.locationField = value;
+            }
+        }
 
         /// <remarks/>
         public long cnpTxnId

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestActivate.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestActivate.cs
@@ -34,6 +34,7 @@ namespace Cnp.Sdk.Test.Functional
             };
             var response = _cnp.Activate(activate);
             Assert.AreEqual("000", response.response);
+            Assert.AreEqual("sandbox", response.location);
         }
 
         [Test]

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestAuth.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestAuth.cs
@@ -758,5 +758,32 @@ namespace Cnp.Sdk.Test.Functional
             Assert.AreEqual("000", response.response);
             Assert.AreEqual(checkDate, response.postDate);
         }
+        
+        [Test]
+        public void SimpleAuthWithLocation()
+        {
+            var authorization = new authorization
+            {
+                id = "1",
+                reportGroup = "Planets",
+                orderId = "12344",
+                amount = 106,
+                orderSource = orderSourceType.ecommerce,
+                card = new cardType
+                {
+                    type = methodOfPaymentTypeEnum.VI,
+                    number = "414100000000000000",
+                    expDate = "1210"
+                },
+                customBilling = new customBilling { phone = "1112223333" }
+            };
+            var response = _cnp.Authorize(authorization);
+
+            DateTime checkDate = new DateTime(0001, 1, 1, 00, 00, 00);
+
+            Assert.AreEqual("000", response.response);
+            Assert.AreEqual(checkDate, response.postDate);
+            Assert.AreEqual("sandbox", response.location);
+        }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestAuthReversal.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestAuthReversal.cs
@@ -64,6 +64,22 @@ namespace Cnp.Sdk.Test.Functional
             var response = _cnp.AuthReversalAsync(reversal, cancellationToken);
             Assert.AreEqual("000", response.Result.response);
         }
+        
+        [Test]
+        public void SimpleAuthReversalWithLocation()
+        {
+            var reversal = new authReversal
+            {
+                id = "1",
+                reportGroup = "Planets",
+                cnpTxnId = 12345678000L,
+                amount = 106,
+                payPalNotes = "Notes"
+            };
 
+            var response = _cnp.AuthReversal(reversal);
+            Assert.AreEqual("sandbox", response.location);
+            Assert.AreEqual("Approved", response.message);
+        }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestBalanceInquiry.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestBalanceInquiry.cs
@@ -35,6 +35,7 @@ namespace Cnp.Sdk.Test.Functional
         
         var response = _cnp.BalanceInquiry(balanceInquiry);
         Assert.AreEqual("000", response.response);
+        Assert.AreEqual("sandbox", response.location);
         }
 
         [Test]

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestCapture.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestCapture.cs
@@ -136,8 +136,26 @@ namespace Cnp.Sdk.Test.Functional
             };
             capture.lodgingInfo.lodgingCharges.Add(new lodgingCharge() { name = lodgingExtraChargeEnum.GIFTSHOP });
             CancellationToken cancellationToken = new CancellationToken(false);
+            
             var response = _cnp.CaptureAsync(capture, cancellationToken);
             Assert.AreEqual("000", response.Result.response);
+        }
+        
+        [Test]
+        public void SimpleCaptureWithLocation()
+        {
+            var capture = new capture
+            {
+                id = "1",
+                cnpTxnId = 123456000,
+                amount = 106,
+                payPalNotes = "Notes",
+                pin = "1234"
+            };
+
+            var response = _cnp.Capture(capture);
+            Assert.AreEqual("sandbox", response.location);
+            Assert.AreEqual("Approved", response.message);
         }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestCaptureGivenAuth.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestCaptureGivenAuth.cs
@@ -275,5 +275,36 @@ namespace Cnp.Sdk.Test.Functional
             var response = _cnp.CaptureGivenAuthAsync(capturegivenauth, cancellationToken);
             Assert.AreEqual("000", response.Result.response);
         }
+        
+        [Test]
+        public void SimpleCaptureGivenAuthWithCardWithLocation()
+        {
+            var capturegivenauth = new captureGivenAuth
+            {
+                id = "1",
+                amount = 106,
+                orderId = "12344",
+                authInformation = new authInformation
+                {
+                    authDate = new DateTime(2002, 10, 9),
+                    authCode = "543216",
+                    authAmount = 12345,
+                },
+                orderSource = orderSourceType.ecommerce,
+                card = new cardType
+                {
+                    type = methodOfPaymentTypeEnum.VI,
+                    number = "4100000000000000",
+                    expDate = "1210",
+                },
+                processingType = processingType.accountFunding,
+                originalNetworkTransactionId = "abc123",
+                originalTransactionAmount = 123456789
+            };
+
+            var response = _cnp.CaptureGivenAuth(capturegivenauth);
+            Assert.AreEqual("sandbox", response.location);
+            Assert.AreEqual("Approved", response.message);
+        }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestCredit.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestCredit.cs
@@ -190,6 +190,29 @@ namespace Cnp.Sdk.Test.Functional
             var response = _cnp.CreditAsync(creditObj, cancellationToken);
             Assert.AreEqual("000", response.Result.response);
         }
+        
+        [Test]
+        public void SimpleCreditWithCardWithLocation()
+        {
+            var creditObj = new credit
+            {
+                id = "1",
+                reportGroup = "planets",
+                amount = 106,
+                orderId = "2111",
+                orderSource = orderSourceType.ecommerce,
+                card = new cardType
+                {
+                    type = methodOfPaymentTypeEnum.VI,
+                    number = "4100000000000001",
+                    expDate = "1210"
+                }
+            };
+
+            var response = _cnp.Credit(creditObj);
+            Assert.AreEqual("sandbox", response.location);
+            Assert.AreEqual("Approved", response.message);
+        }
 
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestCustomer.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestCustomer.cs
@@ -34,6 +34,7 @@ namespace Cnp.Sdk.Test.Functional {
 
             var response = _cnp.CustomerCredit(customerCredit);
             Assert.AreEqual("000", response.response);
+            Assert.AreEqual("sandbox", response.location);
         }
         
         [Test]

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestDeactivate.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestDeactivate.cs
@@ -34,6 +34,7 @@ namespace Cnp.Sdk.Test.Functional
 
             var response = _cnp.Deactivate(deactivate);
             Assert.AreEqual("000", response.response);
+            Assert.AreEqual("sandbox", response.location);
         }
 
     }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestEcheckCredit.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestEcheckCredit.cs
@@ -28,6 +28,7 @@ namespace Cnp.Sdk.Test.Functional
 
             var response = _cnp.EcheckCredit(echeckcredit);
             Assert.AreEqual("Approved", response.message);
+            Assert.AreEqual("sandbox", response.location);
         }
         
         [Test]

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestEcheckCredit.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestEcheckCredit.cs
@@ -29,6 +29,22 @@ namespace Cnp.Sdk.Test.Functional
             var response = _cnp.EcheckCredit(echeckcredit);
             Assert.AreEqual("Approved", response.message);
         }
+        
+        [Test]
+        public void SimpleEcheckCreditWithLocation()
+        {
+            var echeckcredit = new echeckCredit
+            {
+                id = "1",
+                reportGroup = "Planets",
+                amount = 12L,
+                cnpTxnId = 123456789101112L,
+            };
+
+            var response = _cnp.EcheckCredit(echeckcredit);
+            Assert.AreEqual("sandbox", response.location);
+            Assert.AreEqual("Approved", response.message);
+        }
 
         [Test]
         public void NoCnpTxnId()

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestEcheckRedeposit.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestEcheckRedeposit.cs
@@ -29,6 +29,21 @@ namespace Cnp.Sdk.Test.Functional
             var response = _cnp.EcheckRedeposit(echeckredeposit);
             Assert.AreEqual("Approved", response.message);
         }
+        
+        [Test]
+        public void simpleEcheckRedepositWithLocation()
+        {
+            var echeckredeposit = new echeckRedeposit
+            {
+                id = "1",
+                reportGroup = "Planets",
+                cnpTxnId = 123456
+            };
+
+            var response = _cnp.EcheckRedeposit(echeckredeposit);
+            Assert.AreEqual("sandbox", response.location);
+            Assert.AreEqual("Approved", response.message);
+        }
 
         [Test]
         public void EcheckRedepositWithEcheck()

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestEcheckSale.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestEcheckSale.cs
@@ -378,5 +378,37 @@ namespace Cnp.Sdk.Test.Functional
             var response = _cnp.EcheckSaleAsync(echeckSaleObj, cancellationToken);
             StringAssert.AreEqualIgnoringCase("000", response.Result.response);
         }
+        
+        [Test]
+        public void TestEcheckSaleWithLocation()
+        {
+            var echeckSaleObj = new echeckSale
+            {
+                id = "1",
+                reportGroup = "Planets",
+                amount = 123456,
+                orderId = "12345",
+                orderSource = orderSourceType.ecommerce,
+                echeck = new echeckType
+                {
+                    accType = echeckAccountTypeEnum.Checking,
+                    accNum = "12345657890",
+                    routingNum = "123456789",
+                    checkNum = "123455"
+                },
+                billToAddress = new contact
+                {
+                    name = "Bob",
+                    city = "lowell",
+                    state = "MA",
+                    email = "cnp.com"
+                }
+            };
+
+
+            var response = _cnp.EcheckSale(echeckSaleObj);
+            StringAssert.AreEqualIgnoringCase("Approved", response.message);
+            Assert.AreEqual("sandbox", response.location);
+        }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestEcheckSale.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestEcheckSale.cs
@@ -45,6 +45,38 @@ namespace Cnp.Sdk.Test.Functional
             var response = _cnp.EcheckSale(echeckSaleObj);
             StringAssert.AreEqualIgnoringCase("Approved", response.message);
         }
+        
+        [Test]
+        public void SimpleEcheckSaleWithEcheckWithLocation()
+        {
+            var echeckSaleObj = new echeckSale
+            {
+                id = "1",
+                reportGroup = "Planets",
+                amount = 123456,
+                orderId = "12345",
+                orderSource = orderSourceType.ecommerce,
+                echeck = new echeckType
+                {
+                    accType = echeckAccountTypeEnum.Checking,
+                    accNum = "12345657890",
+                    routingNum = "123456789",
+                    checkNum = "123455"
+                },
+                billToAddress = new contact
+                {
+                    name = "Bob",
+                    city = "lowell",
+                    state = "MA",
+                    email = "cnp.com"
+                }
+            };
+
+
+            var response = _cnp.EcheckSale(echeckSaleObj);
+            Assert.AreEqual("sandbox", response.location);
+            StringAssert.AreEqualIgnoringCase("Approved", response.message);
+        }
 
         [Test]
         public void EcheckSaleWithCnpTxnId()

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestEcheckVerification.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestEcheckVerification.cs
@@ -44,6 +44,37 @@ namespace Cnp.Sdk.Test.Functional
             var response = _cnp.EcheckVerification(echeckVerificationObject);
             StringAssert.AreEqualIgnoringCase("Approved", response.message);
         }
+        
+        [Test]
+        public void SimpleEcheckVerificationWithLocation()
+        {
+            var echeckVerificationObject = new echeckVerification
+            {
+                id = "1",
+                reportGroup = "Planets",
+                amount = 123456,
+                orderId = "12345",
+                orderSource = orderSourceType.ecommerce,
+                echeck = new echeckType
+                {
+                    accType = echeckAccountTypeEnum.Checking,
+                    accNum = "12345657890",
+                    routingNum = "123456789",
+                    checkNum = "123455"
+                },
+                billToAddress = new contact
+                {
+                    name = "Bob",
+                    city = "lowell",
+                    state = "MA",
+                    email = "cnp.com"
+                }
+            };
+
+            var response = _cnp.EcheckVerification(echeckVerificationObject);
+            Assert.AreEqual("sandbox", response.location);
+            StringAssert.AreEqualIgnoringCase("Approved", response.message);
+        }
 
         [Test]
         public void EcheckVerificationWithEcheckToken()

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestFastAccessFunding.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestFastAccessFunding.cs
@@ -36,6 +36,7 @@ namespace Cnp.Sdk.Test.Functional
             
             var response = _cnp.FastAccessFunding(fastAccessFunding);
             Assert.AreEqual("000", response.response);
+            Assert.AreEqual("sandbox", response.location);
             StringAssert.AreEqualIgnoringCase("Approved", response.message);
         }
         

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestForceCapture.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestForceCapture.cs
@@ -41,6 +41,31 @@ namespace Cnp.Sdk.Test.Functional
         }
         
         [Test]
+        public void SimpleForceCaptureWithCardWithLocation()
+        {
+            var forcecapture = new forceCapture
+            {
+                id = "1",
+                amount = 106,
+                orderId = "12344",
+                orderSource = orderSourceType.ecommerce,
+                processingType = processingType.accountFunding,
+                card = new cardType
+                {
+                    type = methodOfPaymentTypeEnum.VI,
+                    number = "4100000000000001",
+                    expDate = "1210"
+                },
+                merchantCategoryCode = "1111"
+            };
+            
+
+            var response = _cnp.ForceCapture(forcecapture);
+            Assert.AreEqual("sandbox", response.location);
+            Assert.AreEqual("Approved", response.message);
+        }
+        
+        [Test]
         public void SimpleForceCaptureWithprocessingType()
         {
             var forcecapture = new forceCapture

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestFraudCheck.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestFraudCheck.cs
@@ -87,6 +87,7 @@ namespace Cnp.Sdk.Test.Functional
 
             var fraudCheckResponse = _cnp.FraudCheck(fraudCheck);
             Assert.NotNull(fraudCheckResponse);
+            Assert.AreEqual("sandbox", fraudCheckResponse.location);
             Assert.AreEqual("Call Discover", fraudCheckResponse.message);
             Assert.AreEqual("fail", fraudCheckResponse.advancedFraudResults.deviceReviewStatus);
 

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestGiftCard.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestGiftCard.cs
@@ -139,6 +139,31 @@ namespace Cnp.Sdk.Test.Functional
             var response = _cnp.GiftCardCapture(giftCardCapture);
             Assert.AreEqual("Approved", response.message);
         }
+        
+        [Test]
+        public void TestGiftCardCaptureWithLocation()
+        {
+            var giftCardCapture = new giftCardCapture
+            {
+                id = "1",
+                reportGroup = "Planets",
+                cnpTxnId = 123456000,
+                captureAmount = 106,
+                card = new giftCardCardType
+                {
+                    type = methodOfPaymentTypeEnum.GC,
+                    number = "414100000000000000",
+                    expDate = "1210"
+                },
+                originalRefCode = "abc123",
+                originalAmount = 43534345,
+                originalTxnTime = DateTime.Now
+            };
+
+            var response = _cnp.GiftCardCapture(giftCardCapture);
+            Assert.AreEqual("sandbox", response.location);
+            Assert.AreEqual("Approved", response.message);
+        }
 
         [Test]
         public void TestGiftCardCreditWithTxnId()
@@ -208,6 +233,56 @@ namespace Cnp.Sdk.Test.Functional
 
             var response = _cnp.GiftCardCreditAsync(creditObj, token);
             Assert.AreEqual("000", response.Result.response);
+        }
+        
+        [Test]
+        public void TestGiftCardAuthReversalWithLocation()
+        {
+            var giftCard = new giftCardAuthReversal
+            {
+                id = "1",
+                reportGroup = "Planets",
+                cnpTxnId = 123,
+                card = new giftCardCardType
+                {
+                    type = methodOfPaymentTypeEnum.GC,
+                    number = "414100000000000000",
+                    expDate = "1210"
+                },
+
+                originalRefCode = "abc123",
+                originalAmount = 500,
+                originalTxnTime = DateTime.Now,
+                originalSystemTraceId = 123,
+                originalSequenceNumber = "123456"
+            };
+
+            var response = _cnp.GiftCardAuthReversal(giftCard);
+            Assert.AreEqual("sandbox", response.location);
+            Assert.AreEqual("000", response.response);
+        }
+        
+        [Test]
+        public void TestGiftCardCreditWithOrderIdWithLocation()
+        {
+            var creditObj = new giftCardCredit
+            {
+                id = "1",
+                reportGroup = "planets",
+                creditAmount = 106,
+                orderId = "2111",
+                orderSource = orderSourceType.echeckppd,
+                card = new giftCardCardType
+                {
+                    type = methodOfPaymentTypeEnum.GC,
+                    number = "4100000000000000",
+                    expDate = "1210"
+                }
+            };
+
+            var response = _cnp.GiftCardCredit(creditObj);
+            Assert.AreEqual("sandbox", response.location);
+            Assert.AreEqual("Approved", response.message);
         }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestGiftCardParentReversal.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestGiftCardParentReversal.cs
@@ -41,6 +41,7 @@ namespace Cnp.Sdk.Test.Functional
 
             var response = _cnp.DepositReversal(reversal);
             Assert.AreEqual("Approved", response.message);
+            Assert.AreEqual("sandbox", response.location);
         }
 
         [Test]
@@ -67,6 +68,7 @@ namespace Cnp.Sdk.Test.Functional
 
             var response = _cnp.RefundReversal(reversal);
             Assert.AreEqual("Approved", response.message);
+            Assert.AreEqual("sandbox", response.location);
         }
 
         [Test]
@@ -94,6 +96,7 @@ namespace Cnp.Sdk.Test.Functional
 
             var response = _cnp.ActivateReversal(reversal);
             Assert.AreEqual("Approved", response.message);
+            Assert.AreEqual("sandbox", response.location);
         }
 
         [Test]
@@ -121,6 +124,7 @@ namespace Cnp.Sdk.Test.Functional
 
             var response = _cnp.DeactivateReversal(reversal);
             Assert.AreEqual("Approved", response.message);
+            Assert.AreEqual("sandbox", response.location);
         }
 
         [Test]
@@ -149,6 +153,7 @@ namespace Cnp.Sdk.Test.Functional
 
             var response = _cnp.LoadReversal(reversal);
             Assert.AreEqual("Approved", response.message);
+            Assert.AreEqual("sandbox", response.location);
         }
 
         [Test]
@@ -177,6 +182,7 @@ namespace Cnp.Sdk.Test.Functional
 
             var response = _cnp.UnloadReversal(reversal);
             Assert.AreEqual("Approved", response.message);
+            Assert.AreEqual("sandbox", response.location);
         }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestLoad.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestLoad.cs
@@ -35,6 +35,7 @@ namespace Cnp.Sdk.Test.Functional
 
             var response = _cnp.Load(load);
             Assert.AreEqual("000", response.response);
+            Assert.AreEqual("sandbox", response.location);
         }
 
     }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestPayFac.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestPayFac.cs
@@ -31,6 +31,7 @@ namespace Cnp.Sdk.Test.Functional
 
             var response = _cnp.PayFacCredit(payFacCredit);
             Assert.AreEqual("000", response.response);
+            Assert.AreEqual("sandbox", response.location);
         }
 
         [Test]
@@ -68,6 +69,7 @@ namespace Cnp.Sdk.Test.Functional
 
             var response = _cnp.PayFacDebit(payFacDebit);
             Assert.AreEqual("000", response.response);
+            Assert.AreEqual("sandbox", response.location);
         }
 
         [Test]
@@ -87,6 +89,7 @@ namespace Cnp.Sdk.Test.Functional
             CancellationToken cancellationToken = new CancellationToken(false);
             var response = _cnp.PayFacDebitAsync(payFacDebit, cancellationToken);
             Assert.AreEqual("000", response.Result.response);
+            Assert.AreEqual("sandbox", response.Result.location);
         }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestPayoutOrg.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestPayoutOrg.cs
@@ -29,6 +29,7 @@ namespace Cnp.Sdk.Test.Functional {
 
             var response = _cnp.PayoutOrgCredit(payoutOrgCredit);
             Assert.AreEqual("000", response.response);
+            Assert.AreEqual("sandbox", response.location);
         }
         
         [Test]
@@ -46,6 +47,7 @@ namespace Cnp.Sdk.Test.Functional {
             CancellationToken cancellationToken = new CancellationToken(false);
             var response = _cnp.PayoutOrgCreditAsync(payoutOrgCredit,cancellationToken);
             Assert.AreEqual("000", response.Result.response);
+            Assert.AreEqual("sandbox", response.Result.location);
         }
         
         [Test]
@@ -92,6 +94,7 @@ namespace Cnp.Sdk.Test.Functional {
 
             var response = _cnp.PayoutOrgDebit(payoutOrgDebit);
             Assert.AreEqual("000", response.response);
+            Assert.AreEqual("sandbox", response.location);
         }
         
         [Test]

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestPhysicalCheck.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestPhysicalCheck.cs
@@ -31,6 +31,7 @@ namespace Cnp.Sdk.Test.Functional
 
             var response = _cnp.PhysicalCheckCredit(physicalCheckCredit);
             Assert.AreEqual("000", response.response);
+            Assert.AreEqual("sandbox", response.location);
         }
         
         [Test]
@@ -69,6 +70,7 @@ namespace Cnp.Sdk.Test.Functional
             CancellationToken cancellationToken = new CancellationToken(false);
             var response = _cnp.PhysicalCheckCreditAsync(physicalCheckCredit, cancellationToken);
             Assert.AreEqual("000", response.Result.response);
+            Assert.AreEqual("sandbox", response.Result.location);
         }
         
         [Test]
@@ -87,6 +89,7 @@ namespace Cnp.Sdk.Test.Functional
 
             var response = _cnp.PhysicalCheckDebit(physicalCheckDebit);
             Assert.AreEqual("000", response.response);
+            Assert.AreEqual("sandbox", response.location);
         }
 
         [Test]
@@ -125,6 +128,7 @@ namespace Cnp.Sdk.Test.Functional
             CancellationToken cancellationToken = new CancellationToken(false);
             var response = _cnp.PhysicalCheckDebitAsync(physicalCheckDebit, cancellationToken);
             Assert.AreEqual("000", response.Result.response);
+            Assert.AreEqual("sandbox", response.Result.location);
         }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestQueryTransaction.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestQueryTransaction.cs
@@ -31,6 +31,7 @@ namespace Cnp.Sdk.Test.Functional
             var queryResponse = (queryTransactionResponse)response;
 
             Assert.NotNull(queryResponse);
+            Assert.AreEqual("sandbox", response.location);
             Assert.AreEqual("150", queryResponse.response);
             Assert.AreEqual("Original transaction found", queryResponse.message);
             Assert.AreEqual("000", ((captureResponse)queryResponse.results_max10[0]).response);

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestReserve.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestReserve.cs
@@ -30,6 +30,7 @@ namespace Cnp.Sdk.Test.Functional
             };
 
             var response = _cnp.ReserveCredit(reserveCredit);
+            Assert.AreEqual("sandbox", response.location);
             Assert.AreEqual("000", response.response);
         }
 

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestSale.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestSale.cs
@@ -52,7 +52,6 @@ namespace Cnp.Sdk.Test.Functional
             saleObj.enhancedData.detailTaxes.Add(myDetailTax);
 
             var responseObj = _cnp.Sale(saleObj);
-            Assert.AreEqual("sandbox", saleObj.location);
             StringAssert.AreEqualIgnoringCase("Approved", responseObj.message);
         }
         

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestSale.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestSale.cs
@@ -54,6 +54,46 @@ namespace Cnp.Sdk.Test.Functional
             var responseObj = _cnp.Sale(saleObj);
             StringAssert.AreEqualIgnoringCase("Approved", responseObj.message);
         }
+        
+        [Test]
+        public void SimpleSaleWithTaxTypeIdentifierWithLocation()
+        {
+            var saleObj = new sale
+            {
+                amount = 106,
+                cnpTxnId = 123456,
+                id = "1",
+                orderId = "12344",
+                orderSource = orderSourceType.ecommerce,
+                card = new cardType
+                {
+                    type = methodOfPaymentTypeEnum.VI,
+                    number = "4100000000000000",
+                    expDate = "1210"
+                },
+                enhancedData = new enhancedData
+                {
+                    customerReference = "000000008110801",
+                    salesTax = 23,
+                    deliveryType = enhancedDataDeliveryType.DIG,
+                    taxExempt = false,
+                    detailTaxes = new List<detailTax>()
+
+
+                }
+            };
+
+            var myDetailTax = new detailTax();
+            myDetailTax.taxIncludedInTotal = true;
+            myDetailTax.taxAmount = 23;
+            myDetailTax.taxTypeIdentifier = taxTypeIdentifierEnum.Item00;
+            myDetailTax.cardAcceptorTaxId = "58-1942497";
+            saleObj.enhancedData.detailTaxes.Add(myDetailTax);
+
+            var responseObj = _cnp.Sale(saleObj);
+            Assert.AreEqual("sandbox", responseObj.location);
+            StringAssert.AreEqualIgnoringCase("Approved", responseObj.message);
+        }
 
         [Test]
         public void SimpleSaleWithCard()

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestSale.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestSale.cs
@@ -52,6 +52,7 @@ namespace Cnp.Sdk.Test.Functional
             saleObj.enhancedData.detailTaxes.Add(myDetailTax);
 
             var responseObj = _cnp.Sale(saleObj);
+            Assert.AreEqual("sandbox", saleObj.location);
             StringAssert.AreEqualIgnoringCase("Approved", responseObj.message);
         }
         

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestSubmerchant.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestSubmerchant.cs
@@ -38,6 +38,7 @@ namespace Cnp.Sdk.Test.Functional
             };
 
             var response = _cnp.SubmerchantCredit(submerchantCredit);
+            Assert.AreEqual("sandbox", response.location);
             Assert.AreEqual("000", response.response);
         }
 

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestSubscriptionTxns.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestSubscriptionTxns.cs
@@ -39,6 +39,7 @@ namespace Cnp.Sdk.Test.Functional
             };
             
             var response = _cnp.UpdateSubscription(update);
+            Assert.AreEqual("sandbox", response.location);
             Assert.AreEqual("Approved", response.message);
         }
 

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestToken.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestToken.cs
@@ -27,6 +27,7 @@ namespace Cnp.Sdk.Test.Functional
             };
 
             var rtokenResponse = _cnp.RegisterToken(registerTokenRequest);
+            Assert.AreEqual("sandbox", rtokenResponse.location);
             StringAssert.AreEqualIgnoringCase("Account number was successfully registered", rtokenResponse.message);
         }
 

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestTranslateToLowValueTokenRequest.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestTranslateToLowValueTokenRequest.cs
@@ -30,6 +30,7 @@ namespace Cnp.Sdk.Test.Functional
             var queryResponse = (translateToLowValueTokenResponse)response;
 
             Assert.NotNull(queryResponse);
+            Assert.AreEqual("sandbox", queryResponse.location);
             Assert.AreEqual("822", queryResponse.response);
 
         }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestUnload.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestUnload.cs
@@ -35,6 +35,7 @@ namespace Cnp.Sdk.Test.Functional
 
             var response = _cnp.Unload(unload);
             Assert.AreEqual("000", response.response);
+            Assert.AreEqual("sandbox", response.location);
         }
 
     }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestVendor.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestVendor.cs
@@ -38,6 +38,7 @@ namespace Cnp.Sdk.Test.Functional
 
             var response = _cnp.VendorCredit(vendorCredit);
             Assert.AreEqual("000", response.response);
+            Assert.AreEqual("sandbox", response.location);
         }
 
         [Test]
@@ -89,6 +90,7 @@ namespace Cnp.Sdk.Test.Functional
             CancellationToken cancellationToken = new CancellationToken(false);
             var response = _cnp.VendorCreditAsync(vendorCredit, cancellationToken);
             Assert.AreEqual("000", response.Result.response);
+            Assert.AreEqual("sandbox", response.Result.location);
         }
         
         [Test]
@@ -114,6 +116,7 @@ namespace Cnp.Sdk.Test.Functional
 
             var response = _cnp.VendorDebit(vendorDebit);
             Assert.AreEqual("000", response.response);
+            Assert.AreEqual("sandbox", response.location);
         }
 
         [Test]
@@ -166,6 +169,7 @@ namespace Cnp.Sdk.Test.Functional
             CancellationToken cancellationToken = new CancellationToken(false);
             var response = _cnp.VendorDebitAsync(vendorDebit, cancellationToken);
             Assert.AreEqual("000", response.Result.response);
+            Assert.AreEqual("sandbox", response.Result.location);
         }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestAuthReversal.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestAuthReversal.cs
@@ -57,6 +57,29 @@ namespace Cnp.Sdk.Test.Unit
             cnp.SetCommunication(mockedCommunication);
             cnp.AuthReversal(reversal);
         }
+        
+        [Test]
+        public void TestAuthReversalWithLocation()
+        {
+            authReversal reversal = new authReversal();
+            reversal.cnpTxnId = 3;
+            reversal.amount = 2;
+            reversal.surchargeAmount = 1;
+            reversal.payPalNotes = "note";
+            reversal.reportGroup = "Planets";
+
+            var mock = new Mock<Communications>();
+
+            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n<payPalNotes>note</payPalNotes>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
+                .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' location='sandbox' xmlns='http://www.vantivcnp.com/schema'><authReversalResponse><cnpTxnId>123</cnpTxnId></authReversalResponse></cnpOnlineResponse>");
+
+            Communications mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            var response = cnp.AuthReversal(reversal);
+            
+            Assert.NotNull(response);
+            Assert.AreEqual("sandbox", response.location);
+        }
 
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestAuthorization.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestAuthorization.cs
@@ -636,5 +636,29 @@ namespace Cnp.Sdk.Test.Unit
             Assert.NotNull(authorizationResponse);
             Assert.AreEqual(123, authorizationResponse.cnpTxnId);
         }
+        
+        [Test]
+        public void TestAuthorizationWithLocation()
+        {
+            var auth = new authorization();
+            auth.orderId = "12344";
+            auth.amount = 2;
+            auth.secondaryAmount = 1;
+            auth.orderSource = orderSourceType.ecommerce;
+            auth.reportGroup = "Planets";
+
+            var mock = new Mock<Communications>();
+
+            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<secondaryAmount>1</secondaryAmount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' location='sandbox' xmlns='http://www.vantivcnp.com/schema'><authorizationResponse><cnpTxnId>123</cnpTxnId></authorizationResponse></cnpOnlineResponse>");
+
+            var mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            var authorizationResponse = cnp.Authorize(auth);
+
+            Assert.NotNull(authorizationResponse);
+            Assert.AreEqual(123, authorizationResponse.cnpTxnId);
+            Assert.AreEqual("sandbox", authorizationResponse.location);
+        }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestCancelSubscription.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestCancelSubscription.cs
@@ -33,7 +33,24 @@ namespace Cnp.Sdk.Test.Unit
             cnp.SetCommunication(mockedCommunication);
             cnp.CancelSubscription(update);
         }
+        
+        [Test]
+        public void TestCancelSubscriptionWithLocation()
+        {
+            cancelSubscription update = new cancelSubscription();
+            update.subscriptionId = 12345;
+           
+            var mock = new Mock<Communications>();
 
-
+            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<cnpOnlineRequest.*?<cancelSubscription>\r\n<subscriptionId>12345</subscriptionId>\r\n</cancelSubscription>\r\n</cnpOnlineRequest>.*?.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
+                .Returns("<cnpOnlineResponse version='8.20' response='0' message='Valid Format' location='sandbox' xmlns='http://www.vantivcnp.com/schema'><cancelSubscriptionResponse><subscriptionId>12345</subscriptionId></cancelSubscriptionResponse></cnpOnlineResponse>");
+     
+            Communications mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            var response = cnp.CancelSubscription(update);
+            
+            Assert.NotNull(response);
+            Assert.AreEqual("sandbox", response.location);
+        }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestCapture.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestCapture.cs
@@ -77,6 +77,29 @@ namespace Cnp.Sdk.Test.Unit
             cnp.SetCommunication(mockedCommunication);
             cnp.Capture(capture);
         }
+        
+        [Test]
+        public void TestCaptureWithLocation()
+        {
+            capture capture = new capture();
+            capture.cnpTxnId = 3;
+            capture.amount = 2;
+            capture.payPalNotes = "note";
+            capture.reportGroup = "Planets";
+            capture.pin = "1234";
+
+            var mock = new Mock<Communications>();
+
+            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<payPalNotes>note</payPalNotes>\r\n<pin>1234</pin>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
+                .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' location='sandbox' xmlns='http://www.vantivcnp.com/schema'><captureResponse><cnpTxnId>123</cnpTxnId></captureResponse></cnpOnlineResponse>");
+
+            Communications mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            var response = cnp.Capture(capture);
+            
+            Assert.NotNull(response);
+            Assert.AreEqual("sandbox", response.location);
+        }
 
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestCaptureGivenAuth.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestCaptureGivenAuth.cs
@@ -184,5 +184,27 @@ namespace Cnp.Sdk.Test.Unit
             cnp.SetCommunication(mockedCommunication);
             cnp.CaptureGivenAuth(capture);
         }
+        
+        [Test]
+        public void TestCaptureGivenAuthWithLocation()
+        {
+            captureGivenAuth capture = new captureGivenAuth();
+            capture.amount = 2;
+            capture.secondaryAmount = 1;
+            capture.orderSource = orderSourceType.ecommerce;
+            capture.reportGroup = "Planets";
+
+            var mock = new Mock<Communications>();
+
+            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<secondaryAmount>1</secondaryAmount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
+                .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' location='sandbox' xmlns='http://www.vantivcnp.com/schema'><captureGivenAuthResponse><cnpTxnId>123</cnpTxnId></captureGivenAuthResponse></cnpOnlineResponse>");
+
+            Communications mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            var response = cnp.CaptureGivenAuth(capture);
+            
+            Assert.NotNull(response);
+            Assert.AreEqual("sandbox", response.location);
+        }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestCredit.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestCredit.cs
@@ -261,6 +261,29 @@ namespace Cnp.Sdk.Test.Unit
             cnp.SetCommunication(mockedCommunication);
             cnp.Credit(credit);
         }
+        
+        [Test]
+        public void TestCreditWithLocation()
+        {
+            credit credit = new credit();
+            credit.orderId = "12344";
+            credit.amount = 2;
+            credit.orderSource = orderSourceType.ecommerce;
+            credit.reportGroup = "Planets";
+            credit.actionReason = "SUSPECT_FRAUD";
+           
+            var mock = new Mock<Communications>();
+
+            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<actionReason>SUSPECT_FRAUD</actionReason>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
+                .Returns("<cnpOnlineResponse version='8.10' response='0' message='Valid Format' location='sandbox' xmlns='http://www.vantivcnp.com/schema'><creditResponse><cnpTxnId>123</cnpTxnId></creditResponse></cnpOnlineResponse>");
+     
+            Communications mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            var response = cnp.Credit(credit);
+            
+            Assert.NotNull(response);
+            Assert.AreEqual("sandbox", response.location);
+        }
 
 
     }

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestEcheckRedeposit.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestEcheckRedeposit.cs
@@ -38,6 +38,30 @@ namespace Cnp.Sdk.Test.Unit
             Communications mockedCommunication = mock.Object;
             cnp.SetCommunication(mockedCommunication);
             cnp.EcheckRedeposit(echeckRedeposit);
+        }     
+        
+        [Test]
+        public void TestEcheckRedepositWithLocation()
+        {
+            echeckRedeposit echeckRedeposit = new echeckRedeposit();
+            echeckRedeposit.cnpTxnId = 1;
+            echeckRedeposit.merchantData = new merchantDataType();
+            echeckRedeposit.merchantData.campaign = "camp";
+            echeckRedeposit.merchantData.affiliate = "affil";
+            echeckRedeposit.merchantData.merchantGroupingId = "mgi";
+            echeckRedeposit.customIdentifier = "customIdent";
+           
+            var mock = new Mock<Communications>();
+
+            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<echeckRedeposit.*<cnpTxnId>1</cnpTxnId>.*<merchantData>.*<campaign>camp</campaign>.*<affiliate>affil</affiliate>.*<merchantGroupingId>mgi</merchantGroupingId>.*</merchantData>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
+                .Returns("<cnpOnlineResponse version='8.13' response='0' message='Valid Format' location='sandbox' xmlns='http://www.vantivcnp.com/schema'><echeckRedepositResponse><cnpTxnId>123</cnpTxnId></echeckRedepositResponse></cnpOnlineResponse>");
+     
+            Communications mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            var response = cnp.EcheckRedeposit(echeckRedeposit);
+            
+            Assert.NotNull(response);
+            Assert.AreEqual("sandbox", response.location);
         }            
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestEcheckVerification.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestEcheckVerification.cs
@@ -38,11 +38,14 @@ namespace Cnp.Sdk.Test.Unit
             var mock = new Mock<Communications>();
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<echeckVerification.*<orderId>1</orderId>.*<amount>2</amount.*<merchantData>.*<campaign>camp</campaign>.*<affiliate>affil</affiliate>.*<merchantGroupingId>mgi</merchantGroupingId>.*</merchantData>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<cnpOnlineResponse version='8.13' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><echeckVerificationResponse><cnpTxnId>123</cnpTxnId></echeckVerificationResponse></cnpOnlineResponse>");
+                .Returns("<cnpOnlineResponse version='8.13' response='0' message='Valid Format' location='sandbox' xmlns='http://www.vantivcnp.com/schema'><echeckVerificationResponse><cnpTxnId>123</cnpTxnId></echeckVerificationResponse></cnpOnlineResponse>");
      
             Communications mockedCommunication = mock.Object;
             cnp.SetCommunication(mockedCommunication);
-            cnp.EcheckVerification(echeckVerification);
+            var response = cnp.EcheckVerification(echeckVerification);
+            
+            Assert.NotNull(response);
+            Assert.AreEqual("sandbox", response.location);
         }            
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestEcheckVoid.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestEcheckVoid.cs
@@ -28,11 +28,14 @@ namespace Cnp.Sdk.Test.Unit
             var mock = new Mock<Communications>();
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<echeckVoid.*<cnpTxnId>123456789.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<cnpOnlineResponse version='8.13' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><echeckVoidResponse><cnpTxnId>123</cnpTxnId></echeckVoidResponse></cnpOnlineResponse>");
+                .Returns("<cnpOnlineResponse version='8.13' response='0' message='Valid Format' location='sandbox' xmlns='http://www.vantivcnp.com/schema'><echeckVoidResponse><cnpTxnId>123</cnpTxnId></echeckVoidResponse></cnpOnlineResponse>");
      
             Communications mockedCommunication = mock.Object;
             cnp.SetCommunication(mockedCommunication);
-            cnp.EcheckVoid(echeckVoid);
+            var response = cnp.EcheckVoid(echeckVoid);
+            
+            Assert.NotNull(response);
+            Assert.AreEqual("sandbox", response.location);
         }
 
         

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestForceCapture.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestForceCapture.cs
@@ -184,5 +184,27 @@ namespace Cnp.Sdk.Test.Unit
             cnp.SetCommunication(mockedCommunication);
             cnp.ForceCapture(capture);
         }
+        
+        [Test]
+        public void TestForceCaptureWithLocation()
+        {
+            forceCapture capture = new forceCapture();
+            capture.amount = 2;
+            capture.secondaryAmount = 1;
+            capture.orderSource = orderSourceType.ecommerce;
+            capture.reportGroup = "Planets";
+
+            var mock = new Mock<Communications>();
+
+            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<secondaryAmount>1</secondaryAmount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
+                .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' location='sandbox' xmlns='http://www.vantivcnp.com/schema'><forceCaptureResponse><cnpTxnId>123</cnpTxnId></forceCaptureResponse></cnpOnlineResponse>");
+
+            Communications mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            var response = cnp.ForceCapture(capture);
+            
+            Assert.NotNull(response);
+            Assert.AreEqual("sandbox", response.location);
+        }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestGiftCard.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestGiftCard.cs
@@ -109,7 +109,7 @@ namespace Cnp.Sdk.Test.Unit
             var mock = new Mock<Communications>();
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<cnpTxnId>123456000</cnpTxnId>\r\n<creditAmount>106</creditAmount>\r\n<card>\r\n<type>GC</type>\r\n<number>4100000000000000</number>\r\n<expDate>1210</expDate>\r.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<cnpOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><creditResponse><cnpTxnId>123</cnpTxnId></creditResponse></cnpOnlineResponse>");
+                .Returns("<cnpOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><giftCardCreditResponse><cnpTxnId>123</cnpTxnId></giftCardCreditResponse></cnpOnlineResponse>");
 
             Communications mockedCommunication = mock.Object;
             cnp.SetCommunication(mockedCommunication);
@@ -134,7 +134,7 @@ namespace Cnp.Sdk.Test.Unit
             var mock = new Mock<Communications>();
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<orderId>2111</orderId>\r\n<creditAmount>106</creditAmount>\r\n<orderSource>echeckppd</orderSource>\r\n<card>\r\n<type>GC</type>\r\n<number>4100000000000000</number>\r\n<expDate>1210</expDate>\r.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<cnpOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><creditResponse><cnpTxnId>123</cnpTxnId></creditResponse></cnpOnlineResponse>");
+                .Returns("<cnpOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><giftCardCreditResponse><cnpTxnId>123</cnpTxnId></giftCardCreditResponse></cnpOnlineResponse>");
 
             Communications mockedCommunication = mock.Object;
             cnp.SetCommunication(mockedCommunication);

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestGiftCard.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestGiftCard.cs
@@ -140,5 +140,33 @@ namespace Cnp.Sdk.Test.Unit
             cnp.SetCommunication(mockedCommunication);
             cnp.GiftCardCredit(credit);
         }
+        
+        [Test]
+        public void TestGiftCardCreditWithLocation()
+        {
+            giftCardCredit credit = new giftCardCredit();
+            credit.id = "1";
+            credit.reportGroup = "planets";
+            credit.orderId = "2111";
+            credit.creditAmount = 106;
+            credit.orderSource = orderSourceType.echeckppd;
+            giftCardCardType card = new giftCardCardType();
+            card.type = methodOfPaymentTypeEnum.GC;
+            card.number = "4100000000000000";
+            card.expDate = "1210";
+            credit.card = card;
+
+            var mock = new Mock<Communications>();
+
+            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<orderId>2111</orderId>\r\n<creditAmount>106</creditAmount>\r\n<orderSource>echeckppd</orderSource>\r\n<card>\r\n<type>GC</type>\r\n<number>4100000000000000</number>\r\n<expDate>1210</expDate>\r.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
+                .Returns("<cnpOnlineResponse version='8.10' response='0' message='Valid Format' location='sandbox' xmlns='http://www.vantivcnp.com/schema'><giftCardCreditResponse><cnpTxnId>123</cnpTxnId></giftCardCreditResponse></cnpOnlineResponse>");
+
+            Communications mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            var response = cnp.GiftCardCredit(credit);
+            
+            Assert.NotNull(response);
+            Assert.AreEqual("sandbox", response.location);
+        }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestGiftCardParentReversal.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestGiftCardParentReversal.cs
@@ -40,7 +40,7 @@ namespace Cnp.Sdk.Test.Unit
             var mock = new Mock<Communications>();
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<cnpTxnId>123456000</cnpTxnId>\r\n<card>\r\n<type>GC</type>\r\n<number>414100000000000000</number>\r\n<expDate>1210</expDate>\r\n<pin>1234</pin>\r\n</card>\r\n<originalRefCode>123</originalRefCode>\r\n<originalAmount>123</originalAmount>\r\n<originalTxnTime>2017-01-01T00:00:00Z</originalTxnTime>\r\n<originalSystemTraceId>123</originalSystemTraceId>\r\n<originalSequenceNumber>123456</originalSequenceNumber>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                    .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><authReversalResponse><cnpTxnId>123</cnpTxnId></authReversalResponse></cnpOnlineResponse>");
+                    .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><depositReversalResponse><cnpTxnId>123</cnpTxnId></depositReversalResponse></cnpOnlineResponse>");
 
             Communications mockedCommunication = mock.Object;
             cnp.SetCommunication(mockedCommunication);
@@ -69,7 +69,7 @@ namespace Cnp.Sdk.Test.Unit
             var mock = new Mock<Communications>();
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<cnpTxnId>123456000</cnpTxnId>\r\n<card>\r\n<type>GC</type>\r\n<number>414100000000000000</number>\r\n<expDate>1210</expDate>\r\n<pin>1234</pin>\r\n</card>\r\n<originalRefCode>123</originalRefCode>\r\n<originalAmount>123</originalAmount>\r\n<originalTxnTime>2017-01-01T00:00:00Z</originalTxnTime>\r\n<originalSystemTraceId>123</originalSystemTraceId>\r\n<originalSequenceNumber>123456</originalSequenceNumber>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                    .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><authReversalResponse><cnpTxnId>123</cnpTxnId></authReversalResponse></cnpOnlineResponse>");
+                    .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><refundReversalResponse><cnpTxnId>123</cnpTxnId></refundReversalResponse></cnpOnlineResponse>");
 
             Communications mockedCommunication = mock.Object;
             cnp.SetCommunication(mockedCommunication);
@@ -98,7 +98,7 @@ namespace Cnp.Sdk.Test.Unit
             var mock = new Mock<Communications>();
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<cnpTxnId>123456000</cnpTxnId>\r\n<virtualGiftCardBin>123</virtualGiftCardBin>\r\n<card>\r\n<type>GC</type>\r\n<number>414100000000000000</number>\r\n<expDate>1210</expDate>\r\n<pin>1234</pin>\r\n</card>\r\n<originalRefCode>123</originalRefCode>\r\n<originalAmount>123</originalAmount>\r\n<originalTxnTime>2017-01-01T00:00:00Z</originalTxnTime>\r\n<originalSystemTraceId>123</originalSystemTraceId>\r\n<originalSequenceNumber>123456</originalSequenceNumber>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                    .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><authReversalResponse><cnpTxnId>123</cnpTxnId></authReversalResponse></cnpOnlineResponse>");
+                    .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><activateReversalResponse><cnpTxnId>123</cnpTxnId></activateReversalResponse></cnpOnlineResponse>");
 
             Communications mockedCommunication = mock.Object;
             cnp.SetCommunication(mockedCommunication);
@@ -126,7 +126,7 @@ namespace Cnp.Sdk.Test.Unit
             var mock = new Mock<Communications>();
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<cnpTxnId>123456000</cnpTxnId>\r\n<card>\r\n<type>GC</type>\r\n<number>414100000000000000</number>\r\n<expDate>1210</expDate>\r\n<pin>1234</pin>\r\n</card>\r\n<originalRefCode>123</originalRefCode>\r\n<originalTxnTime>2017-01-01T00:00:00Z</originalTxnTime>\r\n<originalSystemTraceId>123</originalSystemTraceId>\r\n<originalSequenceNumber>123456</originalSequenceNumber>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                    .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><authReversalResponse><cnpTxnId>123</cnpTxnId></authReversalResponse></cnpOnlineResponse>");
+                    .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><deactivateReversalResponse><cnpTxnId>123</cnpTxnId></deactivateReversalResponse></cnpOnlineResponse>");
 
             Communications mockedCommunication = mock.Object;
             cnp.SetCommunication(mockedCommunication);
@@ -155,7 +155,7 @@ namespace Cnp.Sdk.Test.Unit
             var mock = new Mock<Communications>();
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<cnpTxnId>123456000</cnpTxnId>\r\n<card>\r\n<type>GC</type>\r\n<number>414100000000000000</number>\r\n<expDate>1210</expDate>\r\n<pin>1234</pin>\r\n</card>\r\n<originalRefCode>123</originalRefCode>\r\n<originalAmount>123</originalAmount>\r\n<originalTxnTime>2017-01-01T00:00:00Z</originalTxnTime>\r\n<originalSystemTraceId>123</originalSystemTraceId>\r\n<originalSequenceNumber>123456</originalSequenceNumber>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                    .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><authReversalResponse><cnpTxnId>123</cnpTxnId></authReversalResponse></cnpOnlineResponse>");
+                    .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><loadReversalResponse><cnpTxnId>123</cnpTxnId></loadReversalResponse></cnpOnlineResponse>");
 
             Communications mockedCommunication = mock.Object;
             cnp.SetCommunication(mockedCommunication);
@@ -184,7 +184,7 @@ namespace Cnp.Sdk.Test.Unit
             var mock = new Mock<Communications>();
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<cnpTxnId>123456000</cnpTxnId>\r\n<card>\r\n<type>GC</type>\r\n<number>414100000000000000</number>\r\n<expDate>1210</expDate>\r\n<pin>1234</pin>\r\n</card>\r\n<originalRefCode>123</originalRefCode>\r\n<originalAmount>123</originalAmount>\r\n<originalTxnTime>2017-01-01T00:00:00Z</originalTxnTime>\r\n<originalSystemTraceId>123</originalSystemTraceId>\r\n<originalSequenceNumber>123456</originalSequenceNumber>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                    .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><authReversalResponse><cnpTxnId>123</cnpTxnId></authReversalResponse></cnpOnlineResponse>");
+                    .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><unloadReversalResponse><cnpTxnId>123</cnpTxnId></unloadReversalResponse></cnpOnlineResponse>");
 
             Communications mockedCommunication = mock.Object;
             cnp.SetCommunication(mockedCommunication);

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestGiftCardParentReversal.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestGiftCardParentReversal.cs
@@ -69,11 +69,13 @@ namespace Cnp.Sdk.Test.Unit
             var mock = new Mock<Communications>();
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<cnpTxnId>123456000</cnpTxnId>\r\n<card>\r\n<type>GC</type>\r\n<number>414100000000000000</number>\r\n<expDate>1210</expDate>\r\n<pin>1234</pin>\r\n</card>\r\n<originalRefCode>123</originalRefCode>\r\n<originalAmount>123</originalAmount>\r\n<originalTxnTime>2017-01-01T00:00:00Z</originalTxnTime>\r\n<originalSystemTraceId>123</originalSystemTraceId>\r\n<originalSequenceNumber>123456</originalSequenceNumber>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                    .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><refundReversalResponse><cnpTxnId>123</cnpTxnId></refundReversalResponse></cnpOnlineResponse>");
+                    .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' location='sandbox' xmlns='http://www.vantivcnp.com/schema'><refundReversalResponse><cnpTxnId>123</cnpTxnId></refundReversalResponse></cnpOnlineResponse>");
 
             Communications mockedCommunication = mock.Object;
             cnp.SetCommunication(mockedCommunication);
-            cnp.RefundReversal(reversal);
+            var response = cnp.RefundReversal(reversal);
+            
+            Assert.AreEqual("sandbox", response.location);
         }
 
         [Test]
@@ -98,11 +100,14 @@ namespace Cnp.Sdk.Test.Unit
             var mock = new Mock<Communications>();
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<cnpTxnId>123456000</cnpTxnId>\r\n<virtualGiftCardBin>123</virtualGiftCardBin>\r\n<card>\r\n<type>GC</type>\r\n<number>414100000000000000</number>\r\n<expDate>1210</expDate>\r\n<pin>1234</pin>\r\n</card>\r\n<originalRefCode>123</originalRefCode>\r\n<originalAmount>123</originalAmount>\r\n<originalTxnTime>2017-01-01T00:00:00Z</originalTxnTime>\r\n<originalSystemTraceId>123</originalSystemTraceId>\r\n<originalSequenceNumber>123456</originalSequenceNumber>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                    .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><activateReversalResponse><cnpTxnId>123</cnpTxnId></activateReversalResponse></cnpOnlineResponse>");
+                    .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' location='sandbox' xmlns='http://www.vantivcnp.com/schema'><activateReversalResponse><cnpTxnId>123</cnpTxnId></activateReversalResponse></cnpOnlineResponse>");
 
             Communications mockedCommunication = mock.Object;
             cnp.SetCommunication(mockedCommunication);
-            cnp.ActivateReversal(reversal);
+            var response = cnp.ActivateReversal(reversal);
+            
+            Assert.NotNull(response);
+            Assert.AreEqual("sandbox", response.location);
         }
 
         [Test]
@@ -126,11 +131,14 @@ namespace Cnp.Sdk.Test.Unit
             var mock = new Mock<Communications>();
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<cnpTxnId>123456000</cnpTxnId>\r\n<card>\r\n<type>GC</type>\r\n<number>414100000000000000</number>\r\n<expDate>1210</expDate>\r\n<pin>1234</pin>\r\n</card>\r\n<originalRefCode>123</originalRefCode>\r\n<originalTxnTime>2017-01-01T00:00:00Z</originalTxnTime>\r\n<originalSystemTraceId>123</originalSystemTraceId>\r\n<originalSequenceNumber>123456</originalSequenceNumber>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                    .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><deactivateReversalResponse><cnpTxnId>123</cnpTxnId></deactivateReversalResponse></cnpOnlineResponse>");
+                    .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' location='sandbox' xmlns='http://www.vantivcnp.com/schema'><deactivateReversalResponse><cnpTxnId>123</cnpTxnId></deactivateReversalResponse></cnpOnlineResponse>");
 
             Communications mockedCommunication = mock.Object;
             cnp.SetCommunication(mockedCommunication);
-            cnp.DeactivateReversal(reversal);
+            var response = cnp.DeactivateReversal(reversal);
+            
+            Assert.NotNull(response);
+            Assert.AreEqual("sandbox", response.location);
         }
 
         [Test]
@@ -155,11 +163,14 @@ namespace Cnp.Sdk.Test.Unit
             var mock = new Mock<Communications>();
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<cnpTxnId>123456000</cnpTxnId>\r\n<card>\r\n<type>GC</type>\r\n<number>414100000000000000</number>\r\n<expDate>1210</expDate>\r\n<pin>1234</pin>\r\n</card>\r\n<originalRefCode>123</originalRefCode>\r\n<originalAmount>123</originalAmount>\r\n<originalTxnTime>2017-01-01T00:00:00Z</originalTxnTime>\r\n<originalSystemTraceId>123</originalSystemTraceId>\r\n<originalSequenceNumber>123456</originalSequenceNumber>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                    .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><loadReversalResponse><cnpTxnId>123</cnpTxnId></loadReversalResponse></cnpOnlineResponse>");
+                    .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' location='sandbox' xmlns='http://www.vantivcnp.com/schema'><loadReversalResponse><cnpTxnId>123</cnpTxnId></loadReversalResponse></cnpOnlineResponse>");
 
             Communications mockedCommunication = mock.Object;
             cnp.SetCommunication(mockedCommunication);
-            cnp.LoadReversal(reversal);
+            var response = cnp.LoadReversal(reversal);
+            
+            Assert.NotNull(response);
+            Assert.AreEqual("sandbox", response.location);
         }
 
         [Test]
@@ -184,11 +195,14 @@ namespace Cnp.Sdk.Test.Unit
             var mock = new Mock<Communications>();
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<cnpTxnId>123456000</cnpTxnId>\r\n<card>\r\n<type>GC</type>\r\n<number>414100000000000000</number>\r\n<expDate>1210</expDate>\r\n<pin>1234</pin>\r\n</card>\r\n<originalRefCode>123</originalRefCode>\r\n<originalAmount>123</originalAmount>\r\n<originalTxnTime>2017-01-01T00:00:00Z</originalTxnTime>\r\n<originalSystemTraceId>123</originalSystemTraceId>\r\n<originalSequenceNumber>123456</originalSequenceNumber>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                    .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><unloadReversalResponse><cnpTxnId>123</cnpTxnId></unloadReversalResponse></cnpOnlineResponse>");
+                    .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' location='sandbox' xmlns='http://www.vantivcnp.com/schema'><unloadReversalResponse><cnpTxnId>123</cnpTxnId></unloadReversalResponse></cnpOnlineResponse>");
 
             Communications mockedCommunication = mock.Object;
             cnp.SetCommunication(mockedCommunication);
-            cnp.UnloadReversal(reversal);
+            var response = cnp.UnloadReversal(reversal);
+            
+            Assert.NotNull(response);
+            Assert.AreEqual("sandbox", response.location);
         }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestQueryTransactionRequest.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestQueryTransactionRequest.cs
@@ -47,7 +47,7 @@ namespace Cnp.Sdk.Test.Unit
             var mock = new Mock<Communications>();
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<queryTransaction.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<cnpOnlineResponse version='10.10' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><queryTransactionResponse id='FindAuth' reportGroup='Mer5PM1' customerId='1'><response>000</response><responseTime>2015-12-03T10:30:02</responseTime><message>Original transaction found</message><results_max10><authorizationResponse id='1' reportGroup='defaultReportGroup'><cnpTxnId>756027696701750</cnpTxnId><orderId>GenericOrderId</orderId><response>000</response><responseTime>2015-04-14T12:04:59</responseTime><postDate>2015-04-14</postDate><message>Approved</message><authCode>055858</authCode></authorizationResponse><authorizationResponse id='1' reportGroup='defaultReportGroup'><cnpTxnId>756027696701751</cnpTxnId><orderId>GenericOrderId</orderId><response>000</response><responseTime>2015-04-14T12:04:59</responseTime><postDate>2015-04-14</postDate><message>Approved</message><authCode>055858</authCode></authorizationResponse><captureResponse><response>000</response><message>Deposit approved</message></captureResponse></results_max10></queryTransactionResponse></cnpOnlineResponse>");
+                .Returns("<cnpOnlineResponse version='10.10' response='0' message='Valid Format' location='sandbox' xmlns='http://www.vantivcnp.com/schema'><queryTransactionResponse id='FindAuth' reportGroup='Mer5PM1' customerId='1'><response>000</response><responseTime>2015-12-03T10:30:02</responseTime><message>Original transaction found</message><results_max10><authorizationResponse id='1' reportGroup='defaultReportGroup'><cnpTxnId>756027696701750</cnpTxnId><orderId>GenericOrderId</orderId><response>000</response><responseTime>2015-04-14T12:04:59</responseTime><postDate>2015-04-14</postDate><message>Approved</message><authCode>055858</authCode></authorizationResponse><authorizationResponse id='1' reportGroup='defaultReportGroup'><cnpTxnId>756027696701751</cnpTxnId><orderId>GenericOrderId</orderId><response>000</response><responseTime>2015-04-14T12:04:59</responseTime><postDate>2015-04-14</postDate><message>Approved</message><authCode>055858</authCode></authorizationResponse><captureResponse><response>000</response><message>Deposit approved</message></captureResponse></results_max10></queryTransactionResponse></cnpOnlineResponse>");
 
             Communications mockedCommunication = mock.Object;
             cnp.SetCommunication(mockedCommunication);
@@ -55,6 +55,7 @@ namespace Cnp.Sdk.Test.Unit
             queryTransactionResponse queryTransactionResponse = (queryTransactionResponse)response;
 
             Assert.NotNull(queryTransactionResponse);
+            Assert.AreEqual("sandbox", queryTransactionResponse.location);
             Assert.AreEqual("000", queryTransactionResponse.response);
             Assert.AreEqual(3, queryTransactionResponse.results_max10.Count);
             Assert.AreEqual("Original transaction found", queryTransactionResponse.message);
@@ -72,7 +73,7 @@ namespace Cnp.Sdk.Test.Unit
 
             Assert.AreEqual("000", ((captureResponse)queryTransactionResponse.results_max10[2]).response);
             Assert.AreEqual("Deposit approved", ((captureResponse)queryTransactionResponse.results_max10[2]).message);
-
+            
         }
 
         [Test]
@@ -88,7 +89,7 @@ namespace Cnp.Sdk.Test.Unit
             var mock = new Mock<Communications>();
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<queryTransaction.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<cnpOnlineResponse version='10.10' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><queryTransactionUnavailableResponse id='FindAuth' reportGroup='Mer5PM1' customerId='1'><response>152</response><responseTime>2015-12-03T14:45:31</responseTime><message>Original transaction found but response not yet available</message></queryTransactionUnavailableResponse></cnpOnlineResponse>");
+                .Returns("<cnpOnlineResponse version='10.10' response='0' message='Valid Format' location='sandbox' xmlns='http://www.vantivcnp.com/schema'><queryTransactionUnavailableResponse id='FindAuth' reportGroup='Mer5PM1' customerId='1'><response>152</response><responseTime>2015-12-03T14:45:31</responseTime><message>Original transaction found but response not yet available</message></queryTransactionUnavailableResponse></cnpOnlineResponse>");
 
             Communications mockedCommunication = mock.Object;
             cnp.SetCommunication(mockedCommunication);
@@ -97,6 +98,7 @@ namespace Cnp.Sdk.Test.Unit
 
             Assert.NotNull(queryTransactionResponse);
             Assert.AreEqual("152", queryTransactionResponse.response);
+            Assert.AreEqual("sandbox", queryTransactionResponse.location);
         }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestRegisterTokenRequest.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestRegisterTokenRequest.cs
@@ -29,11 +29,14 @@ namespace Cnp.Sdk.Test.Unit
             var mock = new Mock<Communications>();
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<registerTokenRequest.*<accountNumber>4100000000000001</accountNumber>.*</registerTokenRequest>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><registerTokenResponse><cnpTxnId>4</cnpTxnId><response>801</response><message>Token Successfully Registered</message><responseTime>2012-10-10T10:17:03</responseTime></registerTokenResponse></cnpOnlineResponse>");
+                .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' location='sandbox' xmlns='http://www.vantivcnp.com/schema'><registerTokenResponse><cnpTxnId>4</cnpTxnId><response>801</response><message>Token Successfully Registered</message><responseTime>2012-10-10T10:17:03</responseTime></registerTokenResponse></cnpOnlineResponse>");
 
             Communications mockedCommunication = mock.Object;
             cnp.SetCommunication(mockedCommunication);
-            cnp.RegisterToken(register);
+            var response = cnp.RegisterToken(register);
+            
+            Assert.NotNull(response);
+            Assert.AreEqual("sandbox", response.location);
         }
 
         [Test]

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestSale.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestSale.cs
@@ -436,5 +436,28 @@ namespace Cnp.Sdk.Test.Unit
             cnp.SetCommunication(mockedCommunication);
             cnp.Sale(sale);
         }
+        
+        [Test]
+        public void TestSaleWithLocation()
+        {
+            sale sale = new sale();
+            sale.orderId = "12344";
+            sale.amount = 2;
+            sale.orderSource = orderSourceType.ecommerce;
+            sale.reportGroup = "Planets";
+            sale.fraudFilterOverride = false;
+           
+            var mock = new Mock<Communications>();
+
+            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<fraudFilterOverride>false</fraudFilterOverride>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
+                .Returns("<cnpOnlineResponse version='8.10' response='0' message='Valid Format' location='sandbox' xmlns='http://www.vantivcnp.com/schema'><saleResponse><cnpTxnId>123</cnpTxnId></saleResponse></cnpOnlineResponse>");
+     
+            Communications mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            var response = cnp.Sale(sale);
+            
+            Assert.NotNull(response);
+            Assert.AreEqual("sandbox", response.location);
+        }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestUpdateCardValidationNumOnToken.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestUpdateCardValidationNumOnToken.cs
@@ -32,11 +32,14 @@ namespace Cnp.Sdk.Test.Unit
             var mock = new Mock<Communications>();
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<updateCardValidationNumOnToken id=\"123\" reportGroup=\"Default Report Group\".*<orderId>12344</orderId>.*<cnpToken>1111222233334444</cnpToken>.*<cardValidationNum>321</cardValidationNum>.*</updateCardValidationNumOnToken>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><updateCardValidationNumOnTokenResponse><cnpTxnId>4</cnpTxnId><orderId>12344</orderId><response>801</response><message>Token Successfully Registered</message><responseTime>2012-10-10T10:17:03</responseTime></updateCardValidationNumOnTokenResponse></cnpOnlineResponse>");
+                .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' location='sandbox' xmlns='http://www.vantivcnp.com/schema'><updateCardValidationNumOnTokenResponse><cnpTxnId>4</cnpTxnId><orderId>12344</orderId><response>801</response><message>Token Successfully Registered</message><responseTime>2012-10-10T10:17:03</responseTime></updateCardValidationNumOnTokenResponse></cnpOnlineResponse>");
 
             Communications mockedCommunication = mock.Object;
             cnp.SetCommunication(mockedCommunication);
-            cnp.UpdateCardValidationNumOnToken(update);
+            var response = cnp.UpdateCardValidationNumOnToken(update);
+            
+            Assert.NotNull(response);
+            Assert.AreEqual("sandbox", response.location);
         }
 
         [Test]

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestUpdateSubscription.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestUpdateSubscription.cs
@@ -44,7 +44,7 @@ namespace Cnp.Sdk.Test.Unit
             var mock = new Mock<Communications>();
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<cnpOnlineRequest.*?<updateSubscription>\r\n<subscriptionId>12345</subscriptionId>\r\n<planCode>abcdefg</planCode>\r\n<billToAddress>\r\n<name>Greg Dake</name>.*?</billToAddress>\r\n<card>\r\n<type>VI</type>.*?</card>\r\n<billingDate>2002-10-09</billingDate>\r\n</updateSubscription>\r\n</cnpOnlineRequest>.*?.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<cnpOnlineResponse version='8.20' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><updateSubscriptionResponse ><cnpTxnId>456</cnpTxnId><response>000</response><message>Approved</message><responseTime>2013-09-04</responseTime><subscriptionId>12345</subscriptionId></updateSubscriptionResponse></cnpOnlineResponse>");
+                .Returns("<cnpOnlineResponse version='8.20' response='0' message='Valid Format' location='sandbox' xmlns='http://www.vantivcnp.com/schema'><updateSubscriptionResponse ><cnpTxnId>456</cnpTxnId><response>000</response><message>Approved</message><responseTime>2013-09-04</responseTime><subscriptionId>12345</subscriptionId></updateSubscriptionResponse></cnpOnlineResponse>");
      
             var mockedCommunication = mock.Object;
             _cnp.SetCommunication(mockedCommunication);
@@ -52,6 +52,7 @@ namespace Cnp.Sdk.Test.Unit
             Assert.AreEqual("12345", response.subscriptionId);
             Assert.AreEqual("456", response.cnpTxnId);
             Assert.AreEqual("000", response.response);
+            Assert.AreEqual("sandbox", response.location);
             Assert.NotNull(response.responseTime);
         }
 

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestVoid.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestVoid.cs
@@ -28,13 +28,14 @@ namespace Cnp.Sdk.Test.Unit
             var mock = new Mock<Communications>();
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<cnpOnlineResponse version='8.16' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><voidResponse><cnpTxnId>123</cnpTxnId><response>000</response><responseTime>2013-01-31T15:48:09</responseTime><postDate>2013-01-31</postDate><message>Approved</message><recyclingResponse><creditCnpTxnId>456</creditCnpTxnId></recyclingResponse></voidResponse></cnpOnlineResponse>");
+                .Returns("<cnpOnlineResponse version='8.16' response='0' message='Valid Format' location='sandbox' xmlns='http://www.vantivcnp.com/schema'><voidResponse><cnpTxnId>123</cnpTxnId><response>000</response><responseTime>2013-01-31T15:48:09</responseTime><postDate>2013-01-31</postDate><message>Approved</message><recyclingResponse><creditCnpTxnId>456</creditCnpTxnId></recyclingResponse></voidResponse></cnpOnlineResponse>");
      
             Communications mockedCommunication = mock.Object;
             cnp.SetCommunication(mockedCommunication);
             voidResponse response = cnp.DoVoid(voidTxn);
             Assert.AreEqual(123, response.cnpTxnId);
             Assert.AreEqual(456, response.recyclingResponse.creditCnpTxnId);
+            Assert.AreEqual("sandbox", response.location);
         }
 
         [Test]


### PR DESCRIPTION
The goal of this change is to update CNP SDK to v12.12. This version adds a location element in the response to indicate where the request was processed.

Due to a schema issue, the location field is being set in each response manually now. In the future, this will be changed so they'll be deserialized from the response instead. 