### PR TITLE
Adding changes for new SDK release 12.19

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 
 = Worldpay CNP CHANGELOG
 
+==Version 12.19.0 (March 24, 2022)
+* Feature: OrderID element now supports 256 characters.
+* Feature: Optional OrderID element is supported in Capture and Credit transactions.
+* Feature: transactionReversal transaction is not supported in and after cnpAPI v12.19. It has been split into two different transactions:
+			- depositTransactionReversal
+			- refundTransactionReversal
+
 ==Version 12.17.3 (March 23, 2022)
 * BugFix: Fixed echeckAccountTypeEnum.CorpSavings for echeckTokenType
 

--- a/CnpSdkForNet/CnpSdkForNet/CnpBatchRequest.cs
+++ b/CnpSdkForNet/CnpSdkForNet/CnpBatchRequest.cs
@@ -65,7 +65,8 @@ namespace Cnp.Sdk
         private int numPayoutOrgDebit; 
         private int numCustomerCredit;
         private int numCustomerDebit;
-        private int numTransactionReversal;
+        private int numDepositTransactionReversals;
+        private int numRefundTransactionReversals;
 
         private long sumOfAuthorization;
         private long sumOfAuthReversal;
@@ -98,7 +99,8 @@ namespace Cnp.Sdk
         private long payoutOrgDebitAmount;
         private long customerCreditAmount;
         private long customerDebitAmount;
-        private long sumOfTransactionReversal;
+        private long sumOfDepositTransactionReversalAmount;
+        private long sumOfRefundTransactionReversalAmount;
 
         private bool sameDayFunding;
 
@@ -183,7 +185,8 @@ namespace Cnp.Sdk
             numPayoutOrgDebit = 0;
             numCustomerCredit = 0;
             numCustomerDebit = 0;
-            numTransactionReversal = 0;
+            numDepositTransactionReversals = 0;
+            numRefundTransactionReversals = 0;
             sumOfAuthorization = 0;
             sumOfAuthReversal = 0;
             sumOfGiftCardAuthReversal = 0;
@@ -212,7 +215,8 @@ namespace Cnp.Sdk
             payoutOrgDebitAmount = 0;
             physicalCheckDebitAmount = 0;
             fastAccessFundingAmount = 0;
-            sumOfTransactionReversal = 0;
+            sumOfDepositTransactionReversalAmount = 0;
+            sumOfRefundTransactionReversalAmount = 0;
             sameDayFunding = false;
         }
 
@@ -287,9 +291,14 @@ namespace Cnp.Sdk
             return numAuthReversal;
         }
         
-        public int getNumTransactionReversal()
+        public int getNumDepositTransactionReversals()
         {
-            return numTransactionReversal;
+            return numDepositTransactionReversals;
+        }
+
+        public int getNumRefundTransactionReversals()
+        {
+            return numRefundTransactionReversals;
         }
 
         public int getNumGiftCardAuthReversal()
@@ -502,9 +511,14 @@ namespace Cnp.Sdk
             return sumOfAuthReversal;
         }
         
-        public long getSumOfTransactionReversal()
+        public long getSumOfDepositTransactionReversalAmount()
         {
-            return sumOfTransactionReversal;
+            return sumOfDepositTransactionReversalAmount;
+        }
+
+        public long getSumOfRefundTransactionReversalAmount()
+        {
+            return sumOfRefundTransactionReversalAmount;
         }
 
         public long getSumOfGiftCardAuthReversal()
@@ -742,12 +756,27 @@ namespace Cnp.Sdk
             }
         }
         
-        public void addTransactionReversal(transactionReversal txnReversal)
+        public void addDepositTransactionReversal(depositTransactionReversal txnReversal)
         {
             if (numAccountUpdates == 0)
             {
-                numTransactionReversal++;
-                sumOfTransactionReversal += txnReversal.amount;
+                numDepositTransactionReversals++;
+                sumOfDepositTransactionReversalAmount += txnReversal.amount;
+                fillInReportGroup(txnReversal);
+                tempBatchFilePath = saveElement(cnpFile, cnpTime, tempBatchFilePath, txnReversal);
+            }
+            else
+            {
+                throw new CnpOnlineException(accountUpdateErrorMessage);
+            }
+        }
+
+        public void addRefundTransactionReversal(refundTransactionReversal txnReversal)
+        {
+            if (numAccountUpdates == 0)
+            {
+                numRefundTransactionReversals++;
+                sumOfRefundTransactionReversalAmount += txnReversal.amount;
                 fillInReportGroup(txnReversal);
                 tempBatchFilePath = saveElement(cnpFile, cnpTime, tempBatchFilePath, txnReversal);
             }
@@ -1346,10 +1375,16 @@ namespace Cnp.Sdk
                 xmlHeader += "authReversalAmount=\"" + sumOfAuthReversal + "\"\r\n";
             }
 
-            if (numTransactionReversal != 0)
+            if (numDepositTransactionReversals != 0)
             {
-                xmlHeader += "numTransactionReversals=\"" + numTransactionReversal + "\"\r\n";
-                xmlHeader += "transactionReversalAmount=\"" + sumOfTransactionReversal + "\"\r\n"; 
+                xmlHeader += "numDepositTransactionReversals=\"" + numDepositTransactionReversals + "\"\r\n";
+                xmlHeader += "depositTransactionReversalAmount=\"" + sumOfDepositTransactionReversalAmount + "\"\r\n"; 
+            }
+
+            if (numRefundTransactionReversals != 0)
+            {
+                xmlHeader += "numRefundTransactionReversals=\"" + numRefundTransactionReversals + "\"\r\n";
+                xmlHeader += "refundTransactionReversalAmount=\"" + sumOfRefundTransactionReversalAmount + "\"\r\n";
             }
 
             if (numGiftCardAuthReversal != 0)
@@ -1660,7 +1695,8 @@ namespace Cnp.Sdk
                 && numCredit == 0
                 && numSale == 0
                 && numAuthReversal == 0
-                && numTransactionReversal == 0
+                && numDepositTransactionReversals == 0
+                && numRefundTransactionReversals == 0
                 && numEcheckCredit == 0
                 && numEcheckVerification == 0
                 && numEcheckSale == 0

--- a/CnpSdkForNet/CnpSdkForNet/CnpOnline.cs
+++ b/CnpSdkForNet/CnpSdkForNet/CnpOnline.cs
@@ -118,9 +118,13 @@ namespace Cnp.Sdk
                 request.authReversal = (authReversal)transaction;
 
             }
-            else if (transaction is transactionReversal)
+            else if (transaction is depositTransactionReversal)
             {
-                request.transactionReversal = (transactionReversal) transaction;
+                request.depositTransactionReversal = (depositTransactionReversal) transaction;
+            }
+            else if (transaction is refundTransactionReversal)
+            {
+                request.refundTransactionReversal = (refundTransactionReversal)transaction;
             }
             else if (transaction is capture)
             {
@@ -379,20 +383,35 @@ namespace Cnp.Sdk
             }, reversal, cancellationToken);
         }
         
-        public transactionReversalResponse TransactionReversal(transactionReversal reversal)
-        {
-            
+        public depositTransactionReversalResponse DepositTransactionReversal(depositTransactionReversal reversal)
+        {            
             var cnpResponse =  SendRequest(response => response, reversal);
-            var reversalResponse = cnpResponse.transactionReversalResponse;
+            var reversalResponse = cnpResponse.depositTransactionReversalResponse;
             return reversalResponse;
         }
         
-        public Task<transactionReversalResponse> TransactionReversalAsync(transactionReversal reversal, CancellationToken cancellationToken)
+        public Task<depositTransactionReversalResponse> DepositTransactionReversalAsync(depositTransactionReversal reversal, CancellationToken cancellationToken)
         {
             return SendRequestAsync(response =>
             {
-                var transactionReversalResponse = response.transactionReversalResponse;
-                return transactionReversalResponse;
+                var depositTransactionReversalResponse = response.depositTransactionReversalResponse;
+                return depositTransactionReversalResponse;
+            }, reversal, cancellationToken);
+        }
+
+        public refundTransactionReversalResponse RefundTransactionReversal(refundTransactionReversal reversal)
+        {
+            var cnpResponse = SendRequest(response => response, reversal);
+            var reversalResponse = cnpResponse.refundTransactionReversalResponse;
+            return reversalResponse;
+        }
+
+        public Task<refundTransactionReversalResponse> RefundTransactionReversalAsync(refundTransactionReversal reversal, CancellationToken cancellationToken)
+        {
+            return SendRequestAsync(response =>
+            {
+                var refundTransactionReversalResponse = response.refundTransactionReversalResponse;
+                return refundTransactionReversalResponse;
             }, reversal, cancellationToken);
         }
 

--- a/CnpSdkForNet/CnpSdkForNet/CnpSdkForNet.csproj
+++ b/CnpSdkForNet/CnpSdkForNet/CnpSdkForNet.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>dotNetSDKKey.snk</AssemblyOriginatorKeyFile>
-        <PackageVersion>12.17.3</PackageVersion>
+        <PackageVersion>12.19.0</PackageVersion>
         <Title>Vantiv.CnpSdkForNet</Title>
         <Authors>FIS</Authors>
         <Copyright>Copyright © FIS 2020</Copyright>

--- a/CnpSdkForNet/CnpSdkForNet/CnpVersion.cs
+++ b/CnpSdkForNet/CnpSdkForNet/CnpVersion.cs
@@ -8,7 +8,7 @@ namespace Cnp.Sdk
      */
     public class CnpVersion
     {
-        public const String CurrentCNPXMLVersion = "12.17";
-        public const String CurrentCNPSDKVersion = "12.17.3";
+        public const String CurrentCNPXMLVersion = "12.19";
+        public const String CurrentCNPSDKVersion = "12.19.0";
     }
 }

--- a/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
+++ b/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
@@ -54,7 +54,8 @@ namespace Cnp.Sdk
         public submerchantDebit submerchantDebit;
         public queryTransaction queryTransaction;
         public refundReversal refundReversal;
-        public transactionReversal transactionReversal;
+        public depositTransactionReversal depositTransactionReversal;
+        public refundTransactionReversal refundTransactionReversal;
         public registerTokenRequestType registerTokenRequest;
         public sale sale;
         public string merchantId;
@@ -129,7 +130,8 @@ namespace Cnp.Sdk
             else if (payoutOrgCredit != null) xml += payoutOrgCredit.Serialize();
             else if (payoutOrgDebit != null) xml += payoutOrgDebit.Serialize();
             else if (translateToLowValueTokenRequest != null) xml += translateToLowValueTokenRequest.Serialize();
-            else if (transactionReversal != null) xml += transactionReversal.Serialize();
+            else if (depositTransactionReversal != null) xml += depositTransactionReversal.Serialize();
+            else if (refundTransactionReversal != null) xml += refundTransactionReversal.Serialize();
             xml += "\r\n</cnpOnlineRequest>";
 
             return xml;
@@ -615,7 +617,7 @@ namespace Cnp.Sdk
     }
 
     // Authorization Reversal Transaction.
-    public partial class transactionReversal : transactionTypeWithReportGroup
+    public partial class depositTransactionReversal : transactionTypeWithReportGroup
     {
         public long cnpTxnId;
         private long amountField;
@@ -682,7 +684,7 @@ namespace Cnp.Sdk
 
         public override string Serialize()
         {
-            var xml = "\r\n<transactionReversal";
+            var xml = "\r\n<depositTransactionReversal";
             xml += " id=\"" + SecurityElement.Escape(id) + "\"";
             if (customerId != null)
             {
@@ -725,12 +727,128 @@ namespace Cnp.Sdk
                 xml += this.processingInstructionsField.Serialize();
             }
             
-            xml += "\r\n</transactionReversal>";
+            xml += "\r\n</depositTransactionReversal>";
             return xml;
         }
 
     }
-    
+
+    public partial class refundTransactionReversal : transactionTypeWithReportGroup
+    {
+        public long cnpTxnId;
+        private long amountField;
+        private bool amountSet;
+        public long amount
+        {
+            get { return amountField; }
+            set { amountField = value; amountSet = true; }
+        }
+
+        private bool pinSet;
+        private string pinField;
+        public string pin
+        {
+            get { return pinField; }
+            set
+            {
+                pinField = value; pinSet = true;
+            }
+        }
+
+        private bool surchargeAmountIsSet;
+        private int surchargeAmountField;
+
+        public int surchargeAmount
+        {
+            get { return surchargeAmountField; }
+            set { surchargeAmountField = value; surchargeAmountIsSet = true; }
+        }
+
+        private bool enhancedDataIsSet;
+        private enhancedData enhancedDataField;
+        public enhancedData enhancedData
+        {
+            get { return enhancedDataField; }
+            set { enhancedDataField = value; enhancedDataIsSet = true; }
+        }
+
+        private bool processingInstructionsIsSet;
+        private processingInstructions processingInstructionsField;
+        public processingInstructions processingInstructions
+        {
+            get { return processingInstructionsField; }
+            set { processingInstructions = value; processingInstructionsIsSet = true; }
+        }
+
+        private bool customBillingIsSet;
+        private customBilling customBillingField;
+
+        public customBilling customBilling
+        {
+            get { return customBillingField; }
+            set { customBillingField = value; customBillingIsSet = true; }
+        }
+
+        private bool lodgingInfoIsSet;
+        private lodgingInfo lodgingInfoField;
+
+        public lodgingInfo lodgingInfo
+        {
+            get { return lodgingInfoField; }
+            set { lodgingInfoField = value; lodgingInfoIsSet = true; }
+        }
+
+        public override string Serialize()
+        {
+            var xml = "\r\n<refundTransactionReversal";
+            xml += " id=\"" + SecurityElement.Escape(id) + "\"";
+            if (customerId != null)
+            {
+                xml += " customerId=\"" + SecurityElement.Escape(customerId) + "\"";
+            }
+            xml += " reportGroup=\"" + SecurityElement.Escape(reportGroup) + "\">";
+            xml += "\r\n<cnpTxnId>" + cnpTxnId + "</cnpTxnId>";
+            if (amountSet)
+            {
+                xml += "\r\n<amount>" + amountField + "</amount>";
+            }
+
+            if (pinSet)
+            {
+                xml += "\r\n<pin>" + SecurityElement.Escape(pinField) + "</pin>";
+            }
+
+            if (surchargeAmountIsSet)
+            {
+                xml += "\r\n<surchargeAmount>" + surchargeAmountField + "</surchargeAmount>";
+            }
+
+            if (this.customBillingIsSet)
+            {
+                xml += this.customBillingField.Serialize();
+            }
+
+            if (this.enhancedDataIsSet)
+            {
+                xml += this.enhancedDataField.Serialize();
+            }
+
+            if (this.lodgingInfoIsSet)
+            {
+                xml += this.lodgingInfoField.Serialize();
+            }
+
+            if (this.processingInstructionsIsSet)
+            {
+                xml += this.processingInstructionsField.Serialize();
+            }
+
+            xml += "\r\n</refundTransactionReversal>";
+            return xml;
+        }
+
+    }
+
     // Balance Inquiry Transaction.
     public partial class balanceInquiry : transactionTypeWithReportGroup
     {
@@ -786,6 +904,7 @@ namespace Cnp.Sdk
     public partial class capture : transactionTypeWithReportGroupAndPartial
     {
         public long cnpTxnId;
+        public string orderId;
         private long amountField;
         private bool amountSet;
         public long amount
@@ -829,6 +948,7 @@ namespace Cnp.Sdk
             }
             xml += ">";
             xml += "\r\n<cnpTxnId>" + cnpTxnId + "</cnpTxnId>";
+            if (orderId != null) xml += "\r\n<orderId>" + SecurityElement.Escape(orderId) + "</orderId>";
             if (amountSet) xml += "\r\n<amount>" + amountField + "</amount>";
             if (surchargeAmountSet) xml += "\r\n<surchargeAmount>" + surchargeAmountField + "</surchargeAmount>";
             if (enhancedData != null) xml += "\r\n<enhancedData>" + enhancedData.Serialize() + "\r\n</enhancedData>";
@@ -1214,6 +1334,7 @@ namespace Cnp.Sdk
             if (cnpTxnIdSet)
             {
                 xml += "\r\n<cnpTxnId>" + cnpTxnIdField + "</cnpTxnId>";
+                if (orderId != null) xml += "\r\n<orderId>" + SecurityElement.Escape(orderId) + "</orderId>";
                 if (amountSet) xml += "\r\n<amount>" + amountField + "</amount>";
                 if (secondaryAmountSet) xml += "\r\n<secondaryAmount>" + secondaryAmountField + "</secondaryAmount>";
                 if (surchargeAmountSet) xml += "\r\n<surchargeAmount>" + surchargeAmountField + "</surchargeAmount>";

--- a/CnpSdkForNet/CnpSdkForNet/XmlResponseFields.cs
+++ b/CnpSdkForNet/CnpSdkForNet/XmlResponseFields.cs
@@ -1021,7 +1021,27 @@ namespace Cnp.Sdk
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.vantivcnp.com/schema")]
-    public partial class transactionReversalRecyclingResponseType
+    public partial class depositTransactionReversalRecyclingResponseType
+    {
+
+        private long creditCnpTxnIdField;
+
+        /// <remarks/>
+        public long creditCnpTxnId
+        {
+            get { return this.creditCnpTxnIdField; }
+            set { this.creditCnpTxnIdField = value; }
+        }
+
+    }
+
+    /// <remarks/>
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "2.0.50727.42")]
+    [System.SerializableAttribute()]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.ComponentModel.DesignerCategoryAttribute("code")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.vantivcnp.com/schema")]
+    public partial class refundTransactionReversalRecyclingResponseType
     {
 
         private long creditCnpTxnIdField;
@@ -3148,7 +3168,7 @@ namespace Cnp.Sdk
     [System.ComponentModel.DesignerCategoryAttribute("code")]
     [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.vantivcnp.com/schema")]
     [System.Xml.Serialization.XmlRootAttribute(Namespace = "http://www.vantivcnp.com/schema", IsNullable = false)]
-    public partial class transactionReversalResponse : transactionTypeWithReportGroup
+    public partial class depositTransactionReversalResponse : transactionTypeWithReportGroup
     {
         private long cnpTxnIdField;
 
@@ -3164,7 +3184,7 @@ namespace Cnp.Sdk
 
         private string locationField;
 
-        private transactionReversalRecyclingResponseType recyclingResponseField;
+        private depositTransactionReversalRecyclingResponseType depositRecyclingResponseField;
 
         /// <remarks/>
         public long cnpTxnId
@@ -3256,10 +3276,132 @@ namespace Cnp.Sdk
             set { this.locationField = value; }
         }
 
-        public transactionReversalRecyclingResponseType recyclingResponse
+        public depositTransactionReversalRecyclingResponseType recyclingResponse
         {
-            get { return this.recyclingResponseField; }
-            set { this.recyclingResponseField = value; }
+            get { return this.depositRecyclingResponseField; }
+            set { this.depositRecyclingResponseField = value; }
+        }
+    }
+
+    /// <remarks/>
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "2.0.50727.42")]
+    [System.SerializableAttribute()]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.ComponentModel.DesignerCategoryAttribute("code")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.vantivcnp.com/schema")]
+    [System.Xml.Serialization.XmlRootAttribute(Namespace = "http://www.vantivcnp.com/schema", IsNullable = false)]
+    public partial class refundTransactionReversalResponse : transactionTypeWithReportGroup
+    {
+        private long cnpTxnIdField;
+
+        private string responseField;
+
+        private System.DateTime responseTimeField;
+
+        private System.DateTime postDateField;
+
+        private bool postDateFieldSpecified;
+
+        private string messageField;
+
+        private string locationField;
+
+        private refundTransactionReversalRecyclingResponseType refundRecyclingResponseField;
+
+        /// <remarks/>
+        public long cnpTxnId
+        {
+            get
+            {
+                return this.cnpTxnIdField;
+            }
+            set
+            {
+                this.cnpTxnIdField = value;
+            }
+        }
+
+        /// <remarks/>
+        public string response
+        {
+            get
+            {
+                return this.responseField;
+            }
+            set
+            {
+                this.responseField = value;
+            }
+        }
+
+        /// <remarks/>
+        public System.DateTime responseTime
+        {
+            get
+            {
+                return this.responseTimeField;
+            }
+            set
+            {
+                this.responseTimeField = value;
+            }
+        }
+
+        /// <remarks/>
+        [System.Xml.Serialization.XmlElementAttribute(DataType = "date")]
+        public System.DateTime postDate
+        {
+            get
+            {
+                return this.postDateField;
+            }
+            set
+            {
+                this.postDateField = value;
+            }
+        }
+
+        /// <remarks/>
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        public bool postDateSpecified
+        {
+            get
+            {
+                return this.postDateFieldSpecified;
+            }
+            set
+            {
+                this.postDateFieldSpecified = value;
+            }
+        }
+
+        /// <remarks/>
+        public string message
+        {
+            get
+            {
+                return this.messageField;
+            }
+            set
+            {
+                this.messageField = value;
+            }
+        }
+
+        //TODO: make deserializable
+        public string location
+        {
+            get
+            {
+                return this.locationField;
+            }
+            set { this.locationField = value; }
+        }
+
+        public refundTransactionReversalRecyclingResponseType recyclingResponse
+        {
+            get { return this.refundRecyclingResponseField; }
+            set { this.refundRecyclingResponseField = value; }
         }
     }
 
@@ -5479,7 +5621,8 @@ namespace Cnp.Sdk
         public customerCreditResponse customerCreditResponse;
         public customerDebitResponse customerDebitResponse;
         public translateToLowValueTokenResponse translateToLowValueTokenResponse;
-        public transactionReversalResponse transactionReversalResponse;
+        public depositTransactionReversalResponse depositTransactionReversalResponse;
+        public refundTransactionReversalResponse refundTransactionReversalResponse;
 
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
@@ -5663,7 +5806,8 @@ namespace Cnp.Sdk
         private XmlReader accountUpdateResponseReader;
         private XmlReader authorizationResponseReader;
         private XmlReader authReversalResponseReader;
-        private XmlReader transactionReversalResponseReader;
+        private XmlReader depositTransactionReversalResponseReader;
+        private XmlReader refundTransactionReversalResponseReader;
         private XmlReader translateToLowValueTokenResponseReader;
         private XmlReader giftCardAuthReversalResponseReader;
         private XmlReader captureResponseReader;
@@ -5731,9 +5875,14 @@ namespace Cnp.Sdk
             this.authReversalResponseReader = xmlReader;
         }
         
-        public void setTransactionReversalResponseReader(XmlReader xmlReader)
+        public void setDepositTransactionReversalResponseReader(XmlReader xmlReader)
         {
-            this.transactionReversalResponseReader = xmlReader;
+            this.depositTransactionReversalResponseReader = xmlReader;
+        }
+
+        public void setRefundTransactionReversalResponseReader(XmlReader xmlReader)
+        {
+            this.refundTransactionReversalResponseReader = xmlReader;
         }
 
         public void setTranslateToLowValueTokenResponseReader(XmlReader xmlReader)
@@ -5961,7 +6110,8 @@ namespace Cnp.Sdk
             authorizationResponseReader = new XmlTextReader(filePath);
             translateToLowValueTokenResponseReader = new XmlTextReader(filePath);
             authReversalResponseReader = new XmlTextReader(filePath);
-            transactionReversalResponseReader = new XmlTextReader(filePath);
+            depositTransactionReversalResponseReader = new XmlTextReader(filePath);
+            refundTransactionReversalResponseReader = new XmlTextReader(filePath);
             giftCardAuthReversalResponseReader = new XmlTextReader(filePath);
             captureResponseReader = new XmlTextReader(filePath);
             giftCardCaptureResponseReader = new XmlTextReader(filePath);
@@ -6020,10 +6170,13 @@ namespace Cnp.Sdk
             {
                 authReversalResponseReader.Close();
             }
-
-            if (!transactionReversalResponseReader.ReadToFollowing(("transactionReversalResponse")))
+            if (!depositTransactionReversalResponseReader.ReadToFollowing(("transactionReversalResponse")))
             {
-                transactionReversalResponseReader.Close();
+                depositTransactionReversalResponseReader.Close();
+            }
+            if (!refundTransactionReversalResponseReader.ReadToFollowing(("transactionReversalResponse")))
+            {
+                refundTransactionReversalResponseReader.Close();
             }
             if (!giftCardAuthReversalResponseReader.ReadToFollowing("giftCardAuthReversalResponse"))
             {
@@ -6242,18 +6395,38 @@ namespace Cnp.Sdk
             return null;
         }
         
-        virtual public transactionReversalResponse nextTransactionReversalResponse()
+        virtual public depositTransactionReversalResponse nextDepositTransactionReversalResponse()
         {
-            if (transactionReversalResponseReader.ReadState != ReadState.Closed)
+            if (depositTransactionReversalResponseReader.ReadState != ReadState.Closed)
             {
-                string response = transactionReversalResponseReader.ReadOuterXml();
-                XmlSerializer serializer = new XmlSerializer(typeof(transactionReversalResponse));
+                string response = depositTransactionReversalResponseReader.ReadOuterXml();
+                XmlSerializer serializer = new XmlSerializer(typeof(depositTransactionReversalResponse));
                 StringReader reader = new StringReader(response);
-                transactionReversalResponse i = (transactionReversalResponse)serializer.Deserialize(reader);
+                depositTransactionReversalResponse i = (depositTransactionReversalResponse)serializer.Deserialize(reader);
 
-                if (!transactionReversalResponseReader.ReadToFollowing("transactionReversalResponse"))
+                if (!depositTransactionReversalResponseReader.ReadToFollowing("depositTransactionReversalResponse"))
                 {
-                    transactionReversalResponseReader.Close();
+                    depositTransactionReversalResponseReader.Close();
+                }
+
+                return i;
+            }
+
+            return null;
+        }
+
+        virtual public refundTransactionReversalResponse nextRefundTransactionReversalResponse()
+        {
+            if (refundTransactionReversalResponseReader.ReadState != ReadState.Closed)
+            {
+                string response = refundTransactionReversalResponseReader.ReadOuterXml();
+                XmlSerializer serializer = new XmlSerializer(typeof(refundTransactionReversalResponse));
+                StringReader reader = new StringReader(response);
+                refundTransactionReversalResponse i = (refundTransactionReversalResponse)serializer.Deserialize(reader);
+
+                if (!refundTransactionReversalResponseReader.ReadToFollowing("refundTransactionReversalResponse"))
+                {
+                    refundTransactionReversalResponseReader.Close();
                 }
 
                 return i;

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestAuth.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestAuth.cs
@@ -838,5 +838,31 @@ namespace Cnp.Sdk.Test.Functional
             Assert.AreEqual("000", response.response);
             Assert.AreEqual(checkDate, response.postDate);
         }
+
+        [Test]
+        public void SimpleAuthWithOrderIDLengthGT25()
+        {
+            var authorization = new authorization
+            {
+                id = "1",
+                reportGroup = "Planets",
+                orderId = "orderidmorethan25charactersareacceptednow",
+                amount = 106,
+                orderSource = orderSourceType.ecommerce,
+                card = new cardType
+                {
+                    type = methodOfPaymentTypeEnum.VI,
+                    number = "414100000000000000",
+                    expDate = "1210"
+                },
+                customBilling = new customBilling { phone = "1112223333" }
+            };
+            var response = _cnp.Authorize(authorization);
+
+            DateTime checkDate = new DateTime(0001, 1, 1, 00, 00, 00);
+
+            Assert.AreEqual("000", response.response);
+            Assert.AreEqual(checkDate, response.postDate);
+        }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestCapture.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestCapture.cs
@@ -157,5 +157,22 @@ namespace Cnp.Sdk.Test.Functional
             Assert.AreEqual("sandbox", response.location);
             Assert.AreEqual("Approved", response.message);
         }
+
+        [Test]
+        public void SimpleCaptureWithOptionalOrderID()
+        {
+            var capture = new capture
+            {
+                id = "1",
+                cnpTxnId = 123456000,
+                orderId = "orderidmorethan25charactersareacceptednow",
+                amount = 106,
+                payPalNotes = "Notes",
+                pin = "1234"
+            };
+
+            var response = _cnp.Capture(capture);
+            Assert.AreEqual("Approved", response.message);
+        }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestCredit.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestCredit.cs
@@ -259,5 +259,27 @@ namespace Cnp.Sdk.Test.Functional
             var response = _cnp.Credit(creditObj);
             Assert.AreEqual("Approved", response.message);
         }
+
+        [Test]
+        public void SimpleCreditWithPinAndOptionalOrderID()
+        {
+            var creditObj = new credit
+            {
+                id = "1",
+                reportGroup = "planets",
+                cnpTxnId = 123456000,
+                orderId = "2111",
+                pin = "1234",
+                card = new cardType
+                {
+                    type = methodOfPaymentTypeEnum.VI,
+                    number = "4100000000000001",
+                    expDate = "1210"
+                }
+            };
+
+            var response = _cnp.Credit(creditObj);
+            Assert.AreEqual("Approved", response.message);
+        }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestDepositTransactionReversal.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestDepositTransactionReversal.cs
@@ -5,7 +5,7 @@ using System.Threading;
 namespace Cnp.Sdk.Test.Functional
 {
     [TestFixture]
-    internal class TestTransactionReversal
+    internal class TestDeposiTransactionReversal
     {
         private CnpOnline _cnp;
 
@@ -18,7 +18,7 @@ namespace Cnp.Sdk.Test.Functional
         [Test]
         public void SimpleTransactionReversal()
         {
-            var reversal = new transactionReversal
+            var reversal = new depositTransactionReversal
             {
                 id = "1",
                 reportGroup = "Planets",
@@ -26,14 +26,14 @@ namespace Cnp.Sdk.Test.Functional
                 amount = 106,
             };
 
-            var response = _cnp.TransactionReversal(reversal);
+            var response = _cnp.DepositTransactionReversal(reversal);
             Assert.AreEqual("Approved", response.message);
         }
 
         [Test]
         public void TestTransactionReversalHandleSpecialCharacters()
         {
-            var reversal = new transactionReversal()
+            var reversal = new depositTransactionReversal()
             {
                 id = "1",
                 reportGroup = "Planets",
@@ -43,14 +43,14 @@ namespace Cnp.Sdk.Test.Functional
             };
 
 
-            var response = _cnp.TransactionReversal(reversal);
+            var response = _cnp.DepositTransactionReversal(reversal);
             Assert.AreEqual("Approved", response.message);
         }
 
         [Test]
         public void TestTransactionReversalAsync()
         {
-            var reversal = new transactionReversal
+            var reversal = new depositTransactionReversal
             {
                 id = "1",
                 reportGroup = "Planets",
@@ -60,14 +60,14 @@ namespace Cnp.Sdk.Test.Functional
             };
 
             CancellationToken cancellationToken = new CancellationToken(false);
-            var response = _cnp.TransactionReversalAsync(reversal, cancellationToken);
+            var response = _cnp.DepositTransactionReversalAsync(reversal, cancellationToken);
             Assert.AreEqual("000", response.Result.response);
         }
         
         [Test]
         public void TestSimpleTransactionReversalWithLocation()
         {
-            var reversal = new transactionReversal
+            var reversal = new depositTransactionReversal
             {
                 id = "1",
                 reportGroup = "Planets",
@@ -75,7 +75,7 @@ namespace Cnp.Sdk.Test.Functional
                 amount = 106,
             };
 
-            var response = _cnp.TransactionReversal(reversal);
+            var response = _cnp.DepositTransactionReversal(reversal);
             Assert.AreEqual("sandbox", response.location);
             Assert.AreEqual("Approved", response.message);
         }
@@ -83,7 +83,7 @@ namespace Cnp.Sdk.Test.Functional
         [Test]
         public void TestTransactionReversalWithRecycling()
         {
-            var reversal = new transactionReversal
+            var reversal = new depositTransactionReversal
             {
                 id = "1",
                 reportGroup = "Planets",
@@ -91,7 +91,7 @@ namespace Cnp.Sdk.Test.Functional
                 amount = 106,
             };
 
-            var response = _cnp.TransactionReversal(reversal);
+            var response = _cnp.DepositTransactionReversal(reversal);
             Assert.AreEqual("sandbox", response.location);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual(12345678000L, response.recyclingResponse.creditCnpTxnId);

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestRefundTransactionReversal.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestRefundTransactionReversal.cs
@@ -1,0 +1,100 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+using System.Threading;
+
+namespace Cnp.Sdk.Test.Functional
+{
+    [TestFixture]
+    internal class TestRefundTransactionReversal
+    {
+        private CnpOnline _cnp;
+
+        [OneTimeSetUp]
+        public void SetUpCnp()
+        {
+            _cnp = new CnpOnline();
+        }
+
+        [Test]
+        public void SimpleTransactionReversal()
+        {
+            var reversal = new refundTransactionReversal
+            {
+                id = "1",
+                reportGroup = "Planets",
+                cnpTxnId = 12345678000L,
+                amount = 106,
+            };
+
+            var response = _cnp.RefundTransactionReversal(reversal);
+            Assert.AreEqual("Approved", response.message);
+        }
+
+        [Test]
+        public void TestTransactionReversalHandleSpecialCharacters()
+        {
+            var reversal = new refundTransactionReversal()
+            {
+                id = "1",
+                reportGroup = "Planets",
+                cnpTxnId = 12345678000L,
+                amount = 106,
+                customerId = "<'&\">"
+            };
+
+
+            var response = _cnp.RefundTransactionReversal(reversal);
+            Assert.AreEqual("Approved", response.message);
+        }
+
+        [Test]
+        public void TestTransactionReversalAsync()
+        {
+            var reversal = new refundTransactionReversal
+            {
+                id = "1",
+                reportGroup = "Planets",
+                cnpTxnId = 12345678000L,
+                amount = 106,
+                customerId = "<'&\">"
+            };
+
+            CancellationToken cancellationToken = new CancellationToken(false);
+            var response = _cnp.RefundTransactionReversalAsync(reversal, cancellationToken);
+            Assert.AreEqual("000", response.Result.response);
+        }
+        
+        [Test]
+        public void TestSimpleTransactionReversalWithLocation()
+        {
+            var reversal = new refundTransactionReversal
+            {
+                id = "1",
+                reportGroup = "Planets",
+                cnpTxnId = 12345678000L,
+                amount = 106,
+            };
+
+            var response = _cnp.RefundTransactionReversal(reversal);
+            Assert.AreEqual("sandbox", response.location);
+            Assert.AreEqual("Approved", response.message);
+        }
+        
+        [Test]
+        public void TestTransactionReversalWithRecycling()
+        {
+            var reversal = new refundTransactionReversal
+            {
+                id = "1",
+                reportGroup = "Planets",
+                cnpTxnId = 12345678000L,
+                amount = 106,
+            };
+
+            var response = _cnp.RefundTransactionReversal(reversal);
+            Assert.AreEqual("sandbox", response.location);
+            Assert.AreEqual("Approved", response.message);
+            Assert.AreEqual(12345678000L, response.recyclingResponse.creditCnpTxnId);
+        }
+    }
+}

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestBatchRequest.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestBatchRequest.cs
@@ -151,16 +151,32 @@ merchantId=""01234"">
         }
         
         [Test]
-        public void TestTransactionReversal()
+        public void TestDepositTransactionReversal()
         {
-            var transactionReversal = new transactionReversal();
+            var transactionReversal = new depositTransactionReversal();
             transactionReversal.cnpTxnId = 12345678000;
             transactionReversal.amount = 106;
 
-            batchRequest.addTransactionReversal(transactionReversal);
+            batchRequest.addDepositTransactionReversal(transactionReversal);
 
-            Assert.AreEqual(1, batchRequest.getNumTransactionReversal());
-            Assert.AreEqual(transactionReversal.amount, batchRequest.getSumOfTransactionReversal());
+            Assert.AreEqual(1, batchRequest.getNumDepositTransactionReversals());
+            Assert.AreEqual(transactionReversal.amount, batchRequest.getSumOfDepositTransactionReversalAmount());
+
+            mockCnpFile.Verify(cnpFile => cnpFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), mockCnpTime.Object));
+            mockCnpFile.Verify(cnpFile => cnpFile.AppendLineToFile(mockFilePath, transactionReversal.Serialize()));
+        }
+
+        [Test]
+        public void TestRefundTransactionReversal()
+        {
+            var transactionReversal = new refundTransactionReversal();
+            transactionReversal.cnpTxnId = 12345678000;
+            transactionReversal.amount = 106;
+
+            batchRequest.addRefundTransactionReversal(transactionReversal);
+
+            Assert.AreEqual(1, batchRequest.getNumRefundTransactionReversals());
+            Assert.AreEqual(transactionReversal.amount, batchRequest.getSumOfRefundTransactionReversalAmount());
 
             mockCnpFile.Verify(cnpFile => cnpFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), mockCnpTime.Object));
             mockCnpFile.Verify(cnpFile => cnpFile.AppendLineToFile(mockFilePath, transactionReversal.Serialize()));

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestDepositTransactionReversal.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestDepositTransactionReversal.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Moq;
+using System.Text.RegularExpressions;
+
+
+namespace Cnp.Sdk.Test.Unit
+{
+    [TestFixture]
+    class TestDepositTransactionReversal
+    {
+        
+        private CnpOnline cnp;
+
+        [OneTimeSetUp]
+        public void SetUpCnp()
+        {
+            cnp = new CnpOnline();
+        }
+
+        [Test]
+        public void TestSurchargeAmount()
+        {
+            depositTransactionReversal reversal = new depositTransactionReversal();
+            reversal.cnpTxnId = 3;
+            reversal.amount = 2;
+            reversal.surchargeAmount = 1;
+            reversal.reportGroup = "Planets";
+
+            var mock = new Mock<Communications>();
+
+            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n.*", RegexOptions.Singleline)))
+                .Returns("<cnpOnlineResponse version='12.16' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><depositTransactionReversalResponse><cnpTxnId>3</cnpTxnId></depositTransactionReversalResponse></cnpOnlineResponse>");
+
+            Communications mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            cnp.DepositTransactionReversal(reversal);
+        }
+
+        [Test]
+        public void TestSurchargeAmount_Optional()
+        {
+            depositTransactionReversal reversal = new depositTransactionReversal();
+            reversal.cnpTxnId = 3;
+            reversal.amount = 2;
+            reversal.reportGroup = "Planets";
+
+            var mock = new Mock<Communications>();
+
+            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n.*", RegexOptions.Singleline)))
+                .Returns("<cnpOnlineResponse version='12.16' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><depositTransactionReversalResponse><cnpTxnId>123</cnpTxnId></depositTransactionReversalResponse></cnpOnlineResponse>");
+
+            Communications mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            cnp.DepositTransactionReversal(reversal);
+        }
+        
+        [Test]
+        public void TestTransactionReversalWithLocation()
+        {
+            depositTransactionReversal reversal = new depositTransactionReversal();
+            reversal.cnpTxnId = 3;
+            reversal.amount = 2;
+            reversal.surchargeAmount = 1;
+            reversal.reportGroup = "Planets";
+
+            var mock = new Mock<Communications>();
+
+            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n.*", RegexOptions.Singleline)))
+                .Returns("<cnpOnlineResponse version='12.16' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><depositTransactionReversalResponse><cnpTxnId>123</cnpTxnId><location>sandbox</location></depositTransactionReversalResponse></cnpOnlineResponse>");
+
+            Communications mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            var response = cnp.DepositTransactionReversal(reversal);
+            
+            Assert.NotNull(response);
+            Assert.AreEqual("sandbox", response.location);
+        }
+
+    }
+}

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestRefundTransactionReversal.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestRefundTransactionReversal.cs
@@ -8,7 +8,7 @@ using System.Text.RegularExpressions;
 namespace Cnp.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestTransactionReversal
+    class TestRefundTransactionReversal
     {
         
         private CnpOnline cnp;
@@ -22,7 +22,7 @@ namespace Cnp.Sdk.Test.Unit
         [Test]
         public void TestSurchargeAmount()
         {
-            transactionReversal reversal = new transactionReversal();
+            refundTransactionReversal reversal = new refundTransactionReversal();
             reversal.cnpTxnId = 3;
             reversal.amount = 2;
             reversal.surchargeAmount = 1;
@@ -31,17 +31,17 @@ namespace Cnp.Sdk.Test.Unit
             var mock = new Mock<Communications>();
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n.*", RegexOptions.Singleline)))
-                .Returns("<cnpOnlineResponse version='12.16' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><transactionReversalResponse><cnpTxnId>3</cnpTxnId></transactionReversalResponse></cnpOnlineResponse>");
+                .Returns("<cnpOnlineResponse version='12.16' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><refundTransactionReversalResponse><cnpTxnId>3</cnpTxnId></refundTransactionReversalResponse></cnpOnlineResponse>");
 
             Communications mockedCommunication = mock.Object;
             cnp.SetCommunication(mockedCommunication);
-            cnp.TransactionReversal(reversal);
+            cnp.RefundTransactionReversal(reversal);
         }
 
         [Test]
         public void TestSurchargeAmount_Optional()
         {
-            transactionReversal reversal = new transactionReversal();
+            refundTransactionReversal reversal = new refundTransactionReversal();
             reversal.cnpTxnId = 3;
             reversal.amount = 2;
             reversal.reportGroup = "Planets";
@@ -49,17 +49,17 @@ namespace Cnp.Sdk.Test.Unit
             var mock = new Mock<Communications>();
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n.*", RegexOptions.Singleline)))
-                .Returns("<cnpOnlineResponse version='12.16' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><transactionReversalResponse><cnpTxnId>123</cnpTxnId></transactionReversalResponse></cnpOnlineResponse>");
+                .Returns("<cnpOnlineResponse version='12.16' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><refundTransactionReversalResponse><cnpTxnId>123</cnpTxnId></refundTransactionReversalResponse></cnpOnlineResponse>");
 
             Communications mockedCommunication = mock.Object;
             cnp.SetCommunication(mockedCommunication);
-            cnp.TransactionReversal(reversal);
+            cnp.RefundTransactionReversal(reversal);
         }
         
         [Test]
         public void TestTransactionReversalWithLocation()
         {
-            transactionReversal reversal = new transactionReversal();
+            refundTransactionReversal reversal = new refundTransactionReversal();
             reversal.cnpTxnId = 3;
             reversal.amount = 2;
             reversal.surchargeAmount = 1;
@@ -68,11 +68,11 @@ namespace Cnp.Sdk.Test.Unit
             var mock = new Mock<Communications>();
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n.*", RegexOptions.Singleline)))
-                .Returns("<cnpOnlineResponse version='12.16' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><transactionReversalResponse><cnpTxnId>123</cnpTxnId><location>sandbox</location></transactionReversalResponse></cnpOnlineResponse>");
+                .Returns("<cnpOnlineResponse version='12.16' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><refundTransactionReversalResponse><cnpTxnId>123</cnpTxnId><location>sandbox</location></refundTransactionReversalResponse></cnpOnlineResponse>");
 
             Communications mockedCommunication = mock.Object;
             cnp.SetCommunication(mockedCommunication);
-            var response = cnp.TransactionReversal(reversal);
+            var response = cnp.RefundTransactionReversal(reversal);
             
             Assert.NotNull(response);
             Assert.AreEqual("sandbox", response.location);


### PR DESCRIPTION
**Feature**: OrderID element now supports 256 characters.
**Feature**: Optional OrderID element is supported in Capture and Credit transactions.
**Feature**: transactionReversal transaction is not supported in and after cnpAPI v12.19. It has been split into two different transactions:
- depositTransactionReversal
- refundTransactionReversal