### PR TITLE
Adding new version 12.22.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,15 @@
 
 = Worldpay CNP CHANGELOG
 
+==Version 12.22.0 (March 25, 2022)
+Note: It contains changes from cnpAPI v12.20 & v12.21. In case you need any feature supported by cnpAPI v12.20 or v12.21, please use SDK version 12.22.0.
+*Feature: [cnpAPI v12.22] New element vendorAddress is added in vendorCredit and vendorDebit transaction type.
+*Feature: [cnpAPI v12.22] New addressType is added to support vendorAddress.
+*Feature: [cnpAPI v12.22] Optional element cardholderAddress is added to fastAccessFunding transaction type.
+*Feature: [cnpAPI v12.21] fraudCheck authentication value can support upto 512 characters now.
+*Feature: [cnpAPI v12.20] New methodOfPaymentTypeEnum value IC for Interac Payment has been added.
+*BugFix: Invalid methodOfPaymentTypeEnum.BL has been corrected to PL.
+
 ==Version 12.19.0 (March 24, 2022)
 * Feature: OrderID element now supports 256 characters.
 * Feature: Optional OrderID element is supported in Capture and Credit transactions.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,9 +4,9 @@
 ==Version 12.22.0 (March 25, 2022)
 Note: It contains changes from cnpAPI v12.20 & v12.21. In case you need any feature supported by cnpAPI v12.20 or v12.21, please use SDK version 12.22.0.
 *Feature: [cnpAPI v12.22] New element vendorAddress is added in vendorCredit and vendorDebit transaction type.
-*Feature: [cnpAPI v12.22] New addressType is added to support vendorAddress.
 *Feature: [cnpAPI v12.22] Optional element cardholderAddress is added to fastAccessFunding transaction type.
-*Feature: [cnpAPI v12.21] fraudCheck authentication value can support upto 512 characters now.
+*Feature: [cnpAPI v12.22] New addressType is added to support vendorAddress and cardholderAddress.
+*Feature: [cnpAPI v12.21] fraudCheck authenticationValue can support upto 512 characters now.
 *Feature: [cnpAPI v12.20] New methodOfPaymentTypeEnum value IC for Interac Payment has been added.
 *BugFix: Invalid methodOfPaymentTypeEnum.BL has been corrected to PL.
 

--- a/CnpSdkForNet/CnpSdkForNet/CnpBatchRequest.cs
+++ b/CnpSdkForNet/CnpSdkForNet/CnpBatchRequest.cs
@@ -2240,6 +2240,8 @@ namespace Cnp.Sdk
 
         public echeckType accountInfo { get; set; }
 
+        public addressType vendorAddress { get; set; }
+
         public override string Serialize()
         {
             var xml = "\r\n<vendorCredit ";
@@ -2265,6 +2267,7 @@ namespace Cnp.Sdk
                 xml += accountInfo.Serialize();
                 xml += "</accountInfo>";
             }
+            if (vendorAddress != null) xml += "\r\n<vendorAddress>" + vendorAddress.Serialize() + "</vendorAddress>";
 
             xml += "\r\n</vendorCredit>";
 
@@ -2516,6 +2519,8 @@ namespace Cnp.Sdk
 
         public echeckType accountInfo { get; set; }
 
+        public addressType vendorAddress { get; set; }
+
         public override string Serialize()
         {
             var xml = "\r\n<vendorDebit ";
@@ -2541,7 +2546,7 @@ namespace Cnp.Sdk
                 xml += accountInfo.Serialize();
                 xml += "</accountInfo>";
             }
-
+            if (vendorAddress != null) xml += "\r\n<vendorAddress>" + vendorAddress.Serialize() + "</vendorAddress>";
             xml += "\r\n</vendorDebit>";
 
             return xml;

--- a/CnpSdkForNet/CnpSdkForNet/CnpSdkForNet.csproj
+++ b/CnpSdkForNet/CnpSdkForNet/CnpSdkForNet.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>dotNetSDKKey.snk</AssemblyOriginatorKeyFile>
-        <PackageVersion>12.19.0</PackageVersion>
+        <PackageVersion>12.22.0</PackageVersion>
         <Title>Vantiv.CnpSdkForNet</Title>
         <Authors>FIS</Authors>
         <Copyright>Copyright © FIS 2020</Copyright>

--- a/CnpSdkForNet/CnpSdkForNet/CnpVersion.cs
+++ b/CnpSdkForNet/CnpSdkForNet/CnpVersion.cs
@@ -8,7 +8,7 @@ namespace Cnp.Sdk
      */
     public class CnpVersion
     {
-        public const String CurrentCNPXMLVersion = "12.19";
-        public const String CurrentCNPSDKVersion = "12.19.0";
+        public const String CurrentCNPXMLVersion = "12.22";
+        public const String CurrentCNPSDKVersion = "12.22.0";
     }
 }

--- a/CnpSdkForNet/CnpSdkForNet/XmlFields.cs
+++ b/CnpSdkForNet/CnpSdkForNet/XmlFields.cs
@@ -31,13 +31,16 @@ namespace Cnp.Sdk
         JC,
 
         /// <remarks/>
-        BL,
+        PL,
 
         /// <remarks/>
         EC,
 
         /// <remarks/>
         GC,
+
+        /// <remarks/>
+        IC,
 
         /// <remarks/>
         [System.Xml.Serialization.XmlEnumAttribute("")]

--- a/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
+++ b/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
@@ -2919,7 +2919,7 @@ namespace Cnp.Sdk
         public string submerchantName;
         public string customerName;
         public string fundsTransferId;
-        public string cardholderAddress;
+        public addressType cardholderAddress;
         public int amount;
         private disbursementTypeEnum disbursementTypeField;
         private bool disbursementTypeSet;
@@ -2962,7 +2962,7 @@ namespace Cnp.Sdk
                 xml += "\r\n<amount>" + amount + "</amount>";
                 if (disbursementTypeSet)
                     xml += "\r\n<disbursementType>" + disbursementTypeField + "</disbursementType>";
-                if (cardholderAddress != null) xml += "\r\n<cardholderAddress>" + cardholderAddress + "</cardholderAddress>";
+                if (cardholderAddress != null) xml += "\r\n<cardholderAddress>" + cardholderAddress.Serialize() + "</cardholderAddress>";
                 if (card != null) xml += "\r\n<card>" + card.Serialize() + "</card>";
                 else if (token != null) xml += "\r\n<token>" + token.Serialize() + "</token>";
                 else xml += "\r\n<paypage>" + paypage.Serialize() + "</paypage>";

--- a/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
+++ b/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
@@ -2919,6 +2919,7 @@ namespace Cnp.Sdk
         public string submerchantName;
         public string customerName;
         public string fundsTransferId;
+        public string cardholderAddress;
         public int amount;
         private disbursementTypeEnum disbursementTypeField;
         private bool disbursementTypeSet;
@@ -2961,6 +2962,7 @@ namespace Cnp.Sdk
                 xml += "\r\n<amount>" + amount + "</amount>";
                 if (disbursementTypeSet)
                     xml += "\r\n<disbursementType>" + disbursementTypeField + "</disbursementType>";
+                if (cardholderAddress != null) xml += "\r\n<cardholderAddress>" + cardholderAddress + "</cardholderAddress>";
                 if (card != null) xml += "\r\n<card>" + card.Serialize() + "</card>";
                 else if (token != null) xml += "\r\n<token>" + token.Serialize() + "</token>";
                 else xml += "\r\n<paypage>" + paypage.Serialize() + "</paypage>";
@@ -4853,6 +4855,36 @@ namespace Cnp.Sdk
         ZW,
         RS,
         ME,
+    }
+
+    public partial class addressType
+    {        
+        public string addressLine1;
+        public string addressLine2;
+        public string addressLine3;
+        public string city;
+        public string state;
+        public string zip;
+        private countryTypeEnum countryField;
+        private bool countrySpecified;
+        public countryTypeEnum country
+        {
+            get { return countryField; }
+            set { countryField = value; countrySpecified = true; }
+        }        
+
+        public string Serialize()
+        {
+            var xml = "";            
+            if (addressLine1 != null) xml += "\r\n<addressLine1>" + SecurityElement.Escape(addressLine1) + "</addressLine1>";
+            if (addressLine2 != null) xml += "\r\n<addressLine2>" + SecurityElement.Escape(addressLine2) + "</addressLine2>";
+            if (addressLine3 != null) xml += "\r\n<addressLine3>" + SecurityElement.Escape(addressLine3) + "</addressLine3>";
+            if (city != null) xml += "\r\n<city>" + SecurityElement.Escape(city) + "</city>";
+            if (state != null) xml += "\r\n<state>" + SecurityElement.Escape(state) + "</state>";
+            if (zip != null) xml += "\r\n<zip>" + SecurityElement.Escape(zip) + "</zip>";
+            if (countrySpecified) xml += "\r\n<country>" + countryField + "</country>";            
+            return xml;
+        }
     }
 
     public partial class advancedFraudChecksType

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestFastAccessFunding.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestFastAccessFunding.cs
@@ -39,7 +39,42 @@ namespace Cnp.Sdk.Test.Functional
             Assert.AreEqual("sandbox", response.location);
             StringAssert.AreEqualIgnoringCase("Approved", response.message);
         }
-        
+
+        [Test]
+        public void TestFastAccessFunding_tokenWithCardHolderAddress()
+        {
+            fastAccessFunding fastAccessFunding = new fastAccessFunding();
+            fastAccessFunding.id = "A123456";
+            fastAccessFunding.reportGroup = "FastPayment";
+            fastAccessFunding.fundingSubmerchantId = "SomeSubMerchant";
+            fastAccessFunding.submerchantName = "Some Merchant Inc.";
+            fastAccessFunding.fundsTransferId = "123e4567e89b12d3";
+            fastAccessFunding.amount = 3000;
+            fastAccessFunding.token = new cardTokenType
+            {
+                cnpToken = "1111000101039449",
+                expDate = "1112",
+                cardValidationNum = "987",
+                type = methodOfPaymentTypeEnum.VI,
+            };
+
+            addressType cardHolderAddressType = new addressType();
+            cardHolderAddressType.addressLine1 = "37 Main Street";
+            cardHolderAddressType.addressLine2 = "";
+            cardHolderAddressType.addressLine3 = "";
+            cardHolderAddressType.city = "Augusta";
+            cardHolderAddressType.state = "Wisconsin";
+            cardHolderAddressType.zip = "28209";
+            cardHolderAddressType.country = countryTypeEnum.USA;
+
+            fastAccessFunding.cardholderAddress = cardHolderAddressType;
+
+            var response = _cnp.FastAccessFunding(fastAccessFunding);
+            Assert.AreEqual("000", response.response);
+            Assert.AreEqual("sandbox", response.location);
+            StringAssert.AreEqualIgnoringCase("Approved", response.message);
+        }
+
         [Test]
         [Ignore("Sandbox does not check for mismatch. Production does check.")]
         public void TestFastAccessFunding_mixedNames()

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestSale.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestSale.cs
@@ -217,18 +217,100 @@ namespace Cnp.Sdk.Test.Functional
                 },
                 cardholderAuthentication = new fraudCheckType
                 {
-                    authenticationValue = "123456789012345678901234567890123456789012345678901234567890",
+                    /// Not adding base64 authenticationValue
+                    authenticationValue = "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123",
                 }
             };
 
             try
             {
                 var responseObj = _cnp.Sale(saleObj);
+                Assert.Fail();
             }
             catch (CnpOnlineException e)
             {
                 Assert.True(e.Message.StartsWith("Error validating xml data against the schema"));
             }
+        }
+
+        [Test]
+        public void SimpleSaleWithInvalidFraudCheckLength()
+        {
+            var saleObj = new sale
+            {
+                id = "1",
+                amount = 106,
+                cnpTxnId = 123456,
+                orderId = "12344",
+                orderSource = orderSourceType.ecommerce,
+                card = new cardType
+                {
+                    type = methodOfPaymentTypeEnum.VI,
+                    number = "4100000000000000",
+                    expDate = "1210"
+                },
+                cardholderAuthentication = new fraudCheckType
+                {
+                    ///  base64 value for dummy number
+                    /// '123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
+                    ///  123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
+                    ///  123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
+                    ///  123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
+                    ///  123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
+                    ///  123456789012345678901234567890123456789012345678901234567890123'
+                    ///  
+                    /// System should respond with the error 
+                    /// 'message="Error validating xml data against the schema: cvc-maxLength-valid: Value 
+                    /// 'MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2N
+                    ///  zg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMz
+                    ///  Q1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTA
+                    ///  xMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3
+                    ///  ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzN
+                    ///  DU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MD
+                    ///  EyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc
+                    ///  4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIz' with length = '513' is not
+                    ///  facet-valid with respect to maxLength '512' for type 'authenticationValueType'."'
+                    authenticationValue = "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIz",
+                }
+            };            
+
+            try
+            {
+                var responseObj = _cnp.Sale(saleObj);
+                Assert.Fail();
+            }
+            catch (CnpOnlineException e)
+            {
+                Assert.True(e.Message.Contains("is not facet-valid with respect to maxLength '512'"));
+            }
+        }
+
+        [Test]
+        public void SimpleSaleWithValidIncreasedFraudCheckLength()
+        {
+            var saleObj = new sale
+            {
+                id = "1",
+                amount = 106,
+                cnpTxnId = 123456,
+                orderId = "12344",
+                orderSource = orderSourceType.ecommerce,
+                card = new cardType
+                {
+                    type = methodOfPaymentTypeEnum.IC,
+                    number = "4100000000000000",
+                    expDate = "1210"
+                },
+                cardholderAuthentication = new fraudCheckType
+                {
+                    /// base64 value for dummy number '123456789012345678901234567890123456789012345678901234567890'
+                    /// System should accept the request with length 60 of authenticationValueType
+                    authenticationValue = "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkw",
+                }
+            };
+
+            var responseObj = _cnp.Sale(saleObj);
+            StringAssert.AreEqualIgnoringCase("Approved", responseObj.message);
         }
 
         [Test]

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestVendor.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestVendor.cs
@@ -42,6 +42,42 @@ namespace Cnp.Sdk.Test.Functional
         }
 
         [Test]
+        public void VendorCreditWithVendorAddress()
+        {
+            var vendorCredit = new vendorCredit
+            {
+                // attributes.
+                id = "1",
+                reportGroup = "Default Report Group",
+                // required child elements.
+                accountInfo = new echeckType()
+                {
+                    accType = echeckAccountTypeEnum.Savings,
+                    accNum = "1234",
+                    routingNum = "12345678"
+                },
+                vendorAddress = new addressType()
+                {
+                    addressLine1 = "37 Main Street",
+                    addressLine2 = "",
+                    addressLine3 = "",
+                    city = "Augusta",
+                    state = "Wisconsin",
+                    zip = "28209",
+                    country = countryTypeEnum.USA
+                },
+                amount = 1512l,
+                fundingSubmerchantId = "value for fundingSubmerchantId",
+                fundsTransferId = "value for fundsTransferId",
+                vendorName = "Vantiv"
+            };
+
+            var response = _cnp.VendorCredit(vendorCredit);
+            Assert.AreEqual("000", response.response);
+            Assert.AreEqual("sandbox", response.location);
+        }
+
+        [Test]
         public void VendorCreditWithFundingCustomerId()
         {
             var vendorCredit = new vendorCredit
@@ -92,7 +128,7 @@ namespace Cnp.Sdk.Test.Functional
             Assert.AreEqual("000", response.Result.response);
             Assert.AreEqual("sandbox", response.Result.location);
         }
-        
+
         [Test]
         public void ReserveDebit()
         {
@@ -109,6 +145,42 @@ namespace Cnp.Sdk.Test.Functional
                     routingNum = "12345678"
                 },
                 amount = 1512l,
+                fundingSubmerchantId = "value for fundingSubmerchantId",
+                fundsTransferId = "value for fundsTransferId",
+                vendorName = "WorldPay"
+            };
+
+            var response = _cnp.VendorDebit(vendorDebit);
+            Assert.AreEqual("000", response.response);
+            Assert.AreEqual("sandbox", response.location);
+        }
+
+        [Test]
+        public void TestVendorDebitWithVendorAddress()
+        {
+            var vendorDebit = new vendorDebit
+            {
+                // attributes.
+                id = "1",
+                reportGroup = "Default Report Group",
+                // required child elements.
+                accountInfo = new echeckType()
+                {
+                    accType = echeckAccountTypeEnum.Savings,
+                    accNum = "1234",
+                    routingNum = "12345678"
+                },
+                vendorAddress = new addressType()
+                {
+                    addressLine1 = "37 Main Street",
+                    addressLine2 = "",
+                    addressLine3 = "",
+                    city = "Augusta",
+                    state = "Wisconsin",
+                    zip = "28209",
+                    country = countryTypeEnum.USA
+                },
+                amount = 1512L,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId",
                 vendorName = "WorldPay"

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestBatchRequest.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestBatchRequest.cs
@@ -702,7 +702,45 @@ merchantId=""01234"">
             mockCnpFile.Verify(cnpFile => cnpFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), mockCnpTime.Object));
             mockCnpFile.Verify(cnpFile => cnpFile.AppendLineToFile(mockFilePath, vendorCredit.Serialize()));
         }
-        
+
+        [Test]
+        public void TestAddVendorCreditWithVendorAddress()
+        {
+            var vendorCredit = new vendorCredit();
+            vendorCredit.fundingSubmerchantId = "123456";
+            vendorCredit.vendorName = "merchant";
+            vendorCredit.fundsTransferId = "123467";
+            vendorCredit.amount = 106L;
+            var echeck = new echeckType();
+            echeck.accType = echeckAccountTypeEnum.Checking;
+            echeck.accNum = "12345657890";
+            echeck.routingNum = "123456789";
+            echeck.checkNum = "123455";
+
+            vendorCredit.accountInfo = echeck;
+
+            var vendorAddress = new addressType();
+            vendorAddress.addressLine1 = "37 Main Street";
+            vendorAddress.addressLine2 = "";
+            vendorAddress.addressLine3 = "";
+            vendorAddress.city = "Augusta";
+            vendorAddress.state = "Wisconsin";
+            vendorAddress.zip = "28209";
+            vendorAddress.country = countryTypeEnum.USA;
+
+            vendorCredit.vendorAddress = vendorAddress;
+
+            batchRequest.addVendorCredit(vendorCredit);
+
+            Assert.AreEqual(1, batchRequest.getNumVendorCredit());
+            Assert.AreEqual(106L, batchRequest.getVendorCreditAmount());
+            Assert.AreEqual("\r\n<vendorCredit reportGroup=\"Default Report Group\">\r\n<fundingSubmerchantId>123456</fundingSubmerchantId>\r\n<vendorName>merchant</vendorName>\r\n<fundsTransferId>123467</fundsTransferId>\r\n<amount>106</amount>\r\n<accountInfo>\r\n<accType>Checking</accType>\r\n<accNum>12345657890</accNum>\r\n<routingNum>123456789</routingNum>\r\n<checkNum>123455</checkNum></accountInfo>\r\n<vendorAddress>\r\n<addressLine1>37 Main Street</addressLine1>\r\n<addressLine2></addressLine2>\r\n<addressLine3></addressLine3>\r\n<city>Augusta</city>\r\n<state>Wisconsin</state>\r\n<zip>28209</zip>\r\n<country>USA</country></vendorAddress>\r\n</vendorCredit>",
+               vendorCredit.Serialize());
+
+            mockCnpFile.Verify(cnpFile => cnpFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), mockCnpTime.Object));
+            mockCnpFile.Verify(cnpFile => cnpFile.AppendLineToFile(mockFilePath, vendorCredit.Serialize()));
+        }
+
         [Test]
         public void TestAddPhysicalCheckCredit()
         {
@@ -807,6 +845,43 @@ merchantId=""01234"">
             Assert.AreEqual(1, batchRequest.getNumVendorDebit());
             Assert.AreEqual(106L, batchRequest.getVendorDebitAmount());
             Assert.AreEqual("\r\n<vendorDebit reportGroup=\"Default Report Group\">\r\n<fundingSubmerchantId>123456</fundingSubmerchantId>\r\n<vendorName>merchant</vendorName>\r\n<fundsTransferId>123467</fundsTransferId>\r\n<amount>106</amount>\r\n<accountInfo>\r\n<accType>Checking</accType>\r\n<accNum>12345657890</accNum>\r\n<routingNum>123456789</routingNum>\r\n<checkNum>123455</checkNum></accountInfo>\r\n</vendorDebit>",
+               vendorDebit.Serialize());
+
+            mockCnpFile.Verify(cnpFile => cnpFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), mockCnpTime.Object));
+            mockCnpFile.Verify(cnpFile => cnpFile.AppendLineToFile(mockFilePath, vendorDebit.Serialize()));
+        }
+
+        [Test]
+        public void TestAddVendorDebitWithVendorAddress()
+        {
+            var vendorDebit = new vendorDebit();
+            vendorDebit.fundingSubmerchantId = "123456";
+            vendorDebit.vendorName = "merchant";
+            vendorDebit.fundsTransferId = "123467";
+            vendorDebit.amount = 106L;
+            var echeck = new echeckType();
+            echeck.accType = echeckAccountTypeEnum.Checking;
+            echeck.accNum = "12345657890";
+            echeck.routingNum = "123456789";
+            echeck.checkNum = "123455";
+            vendorDebit.accountInfo = echeck;
+
+            var vendorAddress = new addressType();
+            vendorAddress.addressLine1 = "37 Main Street";
+            vendorAddress.addressLine2 = "";
+            vendorAddress.addressLine3 = "";
+            vendorAddress.city = "Augusta";
+            vendorAddress.state = "Wisconsin";
+            vendorAddress.zip = "28209";
+            vendorAddress.country = countryTypeEnum.USA;
+
+            vendorDebit.vendorAddress = vendorAddress;
+
+            batchRequest.addVendorDebit(vendorDebit);
+
+            Assert.AreEqual(1, batchRequest.getNumVendorDebit());
+            Assert.AreEqual(106L, batchRequest.getVendorDebitAmount());
+            Assert.AreEqual("\r\n<vendorDebit reportGroup=\"Default Report Group\">\r\n<fundingSubmerchantId>123456</fundingSubmerchantId>\r\n<vendorName>merchant</vendorName>\r\n<fundsTransferId>123467</fundsTransferId>\r\n<amount>106</amount>\r\n<accountInfo>\r\n<accType>Checking</accType>\r\n<accNum>12345657890</accNum>\r\n<routingNum>123456789</routingNum>\r\n<checkNum>123455</checkNum></accountInfo>\r\n<vendorAddress>\r\n<addressLine1>37 Main Street</addressLine1>\r\n<addressLine2></addressLine2>\r\n<addressLine3></addressLine3>\r\n<city>Augusta</city>\r\n<state>Wisconsin</state>\r\n<zip>28209</zip>\r\n<country>USA</country></vendorAddress>\r\n</vendorDebit>",
                vendorDebit.Serialize());
 
             mockCnpFile.Verify(cnpFile => cnpFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), mockCnpTime.Object));


### PR DESCRIPTION
Note: It contains changes from cnpAPI v12.20 & v12.21. In case you need any feature supported by cnpAPI v12.20 or v12.21, please use SDK version 12.22.0.
**Feature**: [cnpAPI v12.22] New element vendorAddress is added in vendorCredit and vendorDebit transaction type.
**Feature**: [cnpAPI v12.22] New addressType is added to support vendorAddress.
**Feature**: [cnpAPI v12.22] Optional element cardholderAddress is added to fastAccessFunding transaction type.
**Feature**: [cnpAPI v12.21] fraudCheck authentication value can support upto 512 characters now.
**Feature**: [cnpAPI v12.20] New methodOfPaymentTypeEnum value IC for Interac Payment has been added.
**BugFix**: Invalid methodOfPaymentTypeEnum.BL has been corrected to PL.