### PR TITLE
deprecating threatMetrixSessionId

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 
 = Worldpay CNP CHANGELOG
 
+==Version 12.24.1 (April 21, 2022)
+* BugFix: Starting with CNP API v12.3, threatMetrixSessionId is deprecated. Use webSessionId instead. The use and structure is identical.
+
+
 ==Version 12.24.0 (April 18, 2022)
 Note: It contains changes from cnpAPI v12.23. In case you need any feature supported by cnpAPI v12.23, please use SDK version 12.24.0
 

--- a/CnpSdkForNet/CnpSdkForNet/CnpSdkForNet.csproj
+++ b/CnpSdkForNet/CnpSdkForNet/CnpSdkForNet.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>dotNetSDKKey.snk</AssemblyOriginatorKeyFile>
-        <PackageVersion>12.24.0</PackageVersion>
+        <PackageVersion>12.24.1</PackageVersion>
         <Title>Vantiv.CnpSdkForNet</Title>
         <Authors>FIS</Authors>
         <Copyright>Copyright © FIS 2020</Copyright>

--- a/CnpSdkForNet/CnpSdkForNet/CnpVersion.cs
+++ b/CnpSdkForNet/CnpSdkForNet/CnpVersion.cs
@@ -9,6 +9,6 @@ namespace Cnp.Sdk
     public class CnpVersion
     {
         public const String CurrentCNPXMLVersion = "12.24";
-        public const String CurrentCNPSDKVersion = "12.24.0";
+        public const String CurrentCNPSDKVersion = "12.24.1";
     }
 }

--- a/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
+++ b/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
@@ -5331,7 +5331,9 @@ namespace Cnp.Sdk
 
     public partial class advancedFraudChecksType
     {
+        [Obsolete("threatMetrixSessionId is deprecated, please use webSessionId instead.")]
         public string threatMetrixSessionId;
+        public string webSessionId;
         private string customAttribute1Field;
         private bool customAttribute1Set;
         public string customAttribute1
@@ -5372,6 +5374,7 @@ namespace Cnp.Sdk
         {
             var xml = "";
             if (threatMetrixSessionId != null) xml += "\r\n<threatMetrixSessionId>" + SecurityElement.Escape(threatMetrixSessionId) + "</threatMetrixSessionId>";
+            else if (webSessionId != null) xml += "\r\n<webSessionId>" + SecurityElement.Escape(webSessionId) + "</webSessionId>";
             if (customAttribute1Set) xml += "\r\n<customAttribute1>" + SecurityElement.Escape(customAttribute1Field) + "</customAttribute1>";
             if (customAttribute2Set) xml += "\r\n<customAttribute2>" + SecurityElement.Escape(customAttribute2Field) + "</customAttribute2>";
             if (customAttribute3Set) xml += "\r\n<customAttribute3>" + SecurityElement.Escape(customAttribute3Field) + "</customAttribute3>";

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestFraudCheck.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestFraudCheck.cs
@@ -50,6 +50,50 @@ namespace Cnp.Sdk.Test.Functional
         }
 
         [Test]
+        public void TestFraudCheckWithWebSessionId()
+        {
+            var fraudCheck = new fraudCheck
+            {
+                id = "1",
+                reportGroup = "Planets",
+                advancedFraudChecks = new advancedFraudChecksType
+                {
+                    customAttribute1 = "fail",
+                    customAttribute2 = "60",
+                    customAttribute3 = "7",
+                    customAttribute4 = "jkl",
+                    customAttribute5 = "mno",
+                    webSessionId = "abc123"
+                },
+                billToAddress = new contact
+                {
+                    firstName = "Bob",
+                    lastName = "Bagels",
+                    addressLine1 = "37 Main Street",
+                    city = "Augusta",
+                    state = "Wisconsin",
+                    zip = "28209"
+                },
+                shipToAddress = new contact
+                {
+                    firstName = "P",
+                    lastName = "Sherman",
+                    addressLine1 = "42 Wallaby Way",
+                    city = "Sydney",
+                    state = "New South Wales",
+                    zip = "2127"
+                },
+                amount = 51699
+            };
+
+            var fraudCheckResponse = _cnp.FraudCheck(fraudCheck);
+            Assert.NotNull(fraudCheckResponse);
+            Assert.AreEqual("sandbox", fraudCheckResponse.location);
+            Assert.AreEqual("Approved", fraudCheckResponse.message);
+            Assert.AreEqual("fail", fraudCheckResponse.advancedFraudResults.deviceReviewStatus);
+        }
+
+        [Test]
         public void TestFraudCheckWithAddressAndAmount()
         {
             var fraudCheck = new fraudCheck

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestAdvancedFraudCheck.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestAdvancedFraudCheck.cs
@@ -159,5 +159,31 @@ namespace Cnp.Sdk.Test.Unit
             Assert.AreEqual(742802348034313000, fraudCheckResponse.cnpTxnId);
         }
 
+        [Test]
+        public void TestAdvancedFraudChecksTypeWebSessionId()
+        {
+            fraudCheck fraudCheck = new fraudCheck();
+            advancedFraudChecksType advancedFraudCheck = new advancedFraudChecksType();
+            fraudCheck.advancedFraudChecks = advancedFraudCheck;
+            advancedFraudCheck.webSessionId = "ajhgsdjh";
+            advancedFraudCheck.customAttribute1 = "abc";
+            advancedFraudCheck.customAttribute2 = "def";
+            advancedFraudCheck.customAttribute3 = "ghi";
+            advancedFraudCheck.customAttribute4 = "jkl";
+            advancedFraudCheck.customAttribute5 = "mno";
+
+            var mock = new Mock<Communications>();
+
+            mock.Setup(Communications => Communications.HttpPost(It.IsRegex("..*<webSessionId>ajhgsdjh</webSessionId>\r\n<customAttribute1>abc</customAttribute1>\r\n<customAttribute2>def</customAttribute2>\r\n<customAttribute3>ghi</customAttribute3>\r\n<customAttribute4>jkl</customAttribute4>\r\n<customAttribute5>mno</customAttribute5>\r\n.*", RegexOptions.Singleline)))
+                .Returns("<cnpOnlineResponse version='10.1' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><fraudCheckResponse id='127' reportGroup='Planets' customerId=''><cnpTxnId>742802348034313000</cnpTxnId><response>000</response><message>Approved</message><advancedFraudResults><deviceReviewStatus>pass</deviceReviewStatus><deviceReputationScore>42</deviceReputationScore><triggeredRule>triggered_rule_default</triggeredRule></advancedFraudResults></fraudCheckResponse></cnpOnlineResponse >");
+
+            Communications mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            fraudCheckResponse fraudCheckResponse = cnp.FraudCheck(fraudCheck);
+
+            Assert.NotNull(fraudCheckResponse);
+            Assert.AreEqual(742802348034313000, fraudCheckResponse.cnpTxnId);
+        }
+
     }
 }


### PR DESCRIPTION
==Version 12.24.1 (April 21, 2022)
* BugFix: Starting with CNP API v12.3, threatMetrixSessionId is deprecated. Use webSessionId instead. The use and structure is identical.