### PR TITLE
Feature f205651 v12.30

### DIFF
--- a/CnpSdkForNet/CnpSdkForNet/CnpSdkForNet.csproj
+++ b/CnpSdkForNet/CnpSdkForNet/CnpSdkForNet.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>dotNetSDKKey.snk</AssemblyOriginatorKeyFile>
-        <PackageVersion>12.27.0</PackageVersion>
+        <PackageVersion>12.30.0</PackageVersion>
         <Title>Vantiv.CnpSdkForNet</Title>
         <Authors>FIS</Authors>
         <Copyright>Copyright © FIS 2020</Copyright>

--- a/CnpSdkForNet/CnpSdkForNet/CnpVersion.cs
+++ b/CnpSdkForNet/CnpSdkForNet/CnpVersion.cs
@@ -8,7 +8,7 @@ namespace Cnp.Sdk
      */
     public class CnpVersion
     {
-        public const String CurrentCNPXMLVersion = "12.27";
-        public const String CurrentCNPSDKVersion = "12.27.0";
+        public const String CurrentCNPXMLVersion = "12.30";
+        public const String CurrentCNPSDKVersion = "12.30.0";
     }
 }

--- a/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
+++ b/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
@@ -281,6 +281,7 @@ namespace Cnp.Sdk
         }
         public orderSourceType orderSource;
         public customerInfo customerInfo;
+        public sellerInfo sellerInfo;//12.29
         public contact billToAddress;
         public contact retailerAddress;///12.24
         public additionalCOFData additionalCOFData;
@@ -531,6 +532,25 @@ namespace Cnp.Sdk
         }
         public passengerTransportData passengerTransportData;
         //12.25 and 12.26 end
+
+        //12.30 start
+        private authIndicatorEnum authIndicatorField;
+        private bool authIndicatorSet;
+        public authIndicatorEnum authIndicator
+        {
+            get
+            {
+                return authIndicatorField;
+            }
+            set
+            {
+                authIndicatorField = value;
+                authIndicatorSet = true;
+            }
+        }
+
+        //12.30 end
+
         public bool? skipRealtimeAU;
 
         public string merchantCategoryCode;
@@ -547,6 +567,8 @@ namespace Cnp.Sdk
             if (cnpTxnIdSet)
             {
                 xml += "\r\n<cnpTxnId>" + cnpTxnIdField + "</cnpTxnId>";
+                xml += "\r\n<amount>" + amount + "</amount>";
+                xml += "\r\n<authIndicator>" + authIndicatorField + "</authIndicator>";
             }
             else
             {
@@ -559,6 +581,10 @@ namespace Cnp.Sdk
                 if (customerInfo != null)
                 {
                     xml += "\r\n<customerInfo>" + customerInfo.Serialize() + "\r\n</customerInfo>";
+                }
+                if (sellerInfo != null)
+                {
+                    xml += "\r\n<sellerInfo>" + sellerInfo.Serialize() + "\r\n</sellerInfo>";
                 }
                 if (billToAddress != null)
                 {
@@ -694,6 +720,15 @@ namespace Cnp.Sdk
                     xml += "\r\n<passengerTransportData>" + passengerTransportData.Serialize() + "\r\n</passengerTransportData>";
                 }
                 //end
+
+                //12.30 start
+
+                if (authIndicatorSet)
+                {
+                    xml += "\r\n<authIndicator>" + authIndicatorField + "</authIndicator>";
+                }
+                //end 
+
                 if (merchantData != null)
                 {
                     xml += "\r\n<merchantData>" + merchantData.Serialize() + "\r\n</merchantData>";
@@ -2607,6 +2642,7 @@ namespace Cnp.Sdk
         }
         public orderSourceType orderSource;
         public customerInfo customerInfo;
+        public sellerInfo sellerInfo;//12.29
         public contact billToAddress;
         public contact retailerAddress;///12.24
         public contact shipToAddress;
@@ -2906,6 +2942,10 @@ namespace Cnp.Sdk
             if (customerInfo != null)
             {
                 xml += "\r\n<customerInfo>" + customerInfo.Serialize() + "\r\n</customerInfo>";
+            }
+            if (sellerInfo != null)
+            {
+                xml += "\r\n<sellerInfo>" + sellerInfo.Serialize() + "\r\n</sellerInfo>";
             }
             if (billToAddress != null)
             {
@@ -3720,6 +3760,7 @@ namespace Cnp.Sdk
         SOCIAL,
         MARKETPLACE,
         IN_STORE_KIOSK,
+        MIT// new 12.28
     }
 
     //new 12.25, 12.26 and 12.27 start
@@ -3790,6 +3831,14 @@ namespace Cnp.Sdk
 
     }
     //12.25, 12.26 and 12.27 end
+
+    //new 12.28, 12.29 and 12.30 start
+    public enum authIndicatorEnum
+    {
+        Estimated,
+        Incremental
+    }
+
 
     #endregion
 
@@ -4458,7 +4507,7 @@ namespace Cnp.Sdk
         public string tokenUrl;
         public string expDate;
         public string cardValidationNum;
-	private string authenticatedShopperID;
+	    private string authenticatedShopperID;
         private methodOfPaymentTypeEnum typeField;
         private bool typeSet;
         public methodOfPaymentTypeEnum type
@@ -6207,6 +6256,106 @@ namespace Cnp.Sdk
             {
                 xml += "\r\n<tripLegData>" + tripLegData.Serialize() + "\r\n</tripLegData>";
             }
+            return xml;
+        }
+    }
+
+    //12.29
+    public partial class sellerInfo
+    {
+        public string accountNumber;
+        private int aggregateOrderCountField;
+        private bool aggregateOrderCountSet;
+        public int aggregateOrderCount
+        {
+            get { return aggregateOrderCountField; }
+            set { aggregateOrderCountField = value; aggregateOrderCountSet = true; }
+        }
+
+        private int aggregateOrderDollarsField;
+        private bool aggregateOrderDollarsSet;
+
+        public int aggregateOrderDollars
+        {
+            get { return aggregateOrderDollarsField; }
+            set { aggregateOrderDollarsField = value; aggregateOrderDollarsSet = true; }
+        }
+        public sellerAddress sellerAddress;
+        public string createdDate;
+        public string domain;
+        public string email;
+        public string lastUpdateDate;
+        public string name;
+        public string onboardingEmail;
+        public string onboardingIpAddress;
+        public string parentEntity;
+        public string phone;
+        public string sellerId;
+        public sellerTagsType sellerTags;
+        public string username;
+
+        public string Serialize()
+        {
+            var xml = "";
+            if (accountNumber != null) xml += "\r\n<accountNumber>" + SecurityElement.Escape(accountNumber) + "</accountNumber>";
+            if (aggregateOrderCountSet) xml += "\r\n<aggregateOrderCount>" + aggregateOrderCountField + "</aggregateOrderCount>";
+            if (aggregateOrderDollarsSet) xml += "\r\n<aggregateOrderDollars>" + aggregateOrderDollarsField + "</aggregateOrderDollars>";
+            if (sellerAddress != null)
+            {
+                xml += "\r\n<sellerAddress>" + sellerAddress.Serialize() + "\r\n</sellerAddress>";
+            }
+            return xml;
+            if (createdDate != null) xml += "\r\n<createdDate>" + SecurityElement.Escape(createdDate) + "</createdDate>";
+            if (domain != null) xml += "\r\n<domain>" + SecurityElement.Escape(domain) + "</domain>";
+            if (email != null) xml += "\r\n<email>" + SecurityElement.Escape(email) + "</email>";
+            if (lastUpdateDate != null) xml += "\r\n<lastUpdateDate>" + SecurityElement.Escape(lastUpdateDate) + "</lastUpdateDate>";
+            if (name != null) xml += "\r\n<name>" + SecurityElement.Escape(name) + "</name>";
+            if (onboardingEmail != null) xml += "\r\n<onboardingEmail>" + SecurityElement.Escape(onboardingEmail) + "</onboardingEmail>";
+            if (onboardingIpAddress != null) xml += "\r\n<onboardingIpAddress>" + SecurityElement.Escape(onboardingIpAddress) + "</onboardingIpAddress>";
+            if (parentEntity != null) xml += "\r\n<parentEntity>" + SecurityElement.Escape(parentEntity) + "</parentEntity>";
+            if (phone != null) xml += "\r\n<phone>" + SecurityElement.Escape(phone) + "</phone>";
+            if (sellerId != null) xml += "\r\n<sellerId>" + SecurityElement.Escape(sellerId) + "</sellerId>";
+            if (sellerTags != null)
+            {
+                xml += "\r\n<sellerTags>" + sellerTags.Serialize() + "\r\n</sellerTags>";
+            }
+            if (username != null) xml += "\r\n<username>" + SecurityElement.Escape(username) + "</username>";
+
+            return xml;
+        }
+
+    }
+
+    public partial class sellerAddress
+    {
+        public string sellerStreetaddress;
+        public string sellerUnit;
+        public string sellerPostalcode;
+        public string sellerCity;
+        public string sellerProvincecode;
+        public string sellerCountrycode;
+
+        public string Serialize()
+        {
+            var xml = "";
+            if (sellerStreetaddress != null) xml += "\r\n<sellerStreetaddress>" + SecurityElement.Escape(sellerStreetaddress) + "</sellerStreetaddress>";
+            if (sellerUnit != null) xml += "\r\n<sellerUnit>" + SecurityElement.Escape(sellerUnit) + "</sellerUnit>";
+            if (sellerPostalcode != null) xml += "\r\n<sellerPostalcode>" + SecurityElement.Escape(sellerPostalcode) + "</sellerPostalcode>";
+            if (sellerCity != null) xml += "\r\n<sellerCity>" + SecurityElement.Escape(sellerCity) + "</sellerCity>";
+            if (sellerProvincecode != null) xml += "\r\n<sellerProvincecode>" + SecurityElement.Escape(sellerProvincecode) + "</sellerProvincecode>";
+            if (sellerCountrycode != null) xml += "\r\n<sellerCountrycode>" + SecurityElement.Escape(sellerCountrycode) + "</sellerCountrycode>";
+            return xml;
+        }
+    }
+
+    public partial class sellerTagsType
+    {
+        public string tag;
+
+        public string Serialize()
+        {
+            var xml = "";
+            if (tag != null) xml += "\r\n<tag>" + SecurityElement.Escape(tag) + "</tag>";
             return xml;
         }
     }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestAuth.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestAuth.cs
@@ -1144,5 +1144,139 @@ namespace Cnp.Sdk.Test.Functional
             Assert.AreEqual(false, response.authMax.authMaxApplied);
             Assert.AreEqual(checkDate, response.postDate);
         }
+
+        //12.28,12.29 and 12.30 start
+        [Test]
+        public void SimpleAuthWithOrdChanelEnumMIT()
+        {
+            var authorization = new authorization
+            {
+                id = "1",
+                reportGroup = "Planets",
+                orderId = "12344",
+                amount = 106,
+                orderSource = orderSourceType.ecommerce,
+                authIndicator = authIndicatorEnum.Estimated,
+                card = new cardType
+                {
+                    type = methodOfPaymentTypeEnum.VI,
+                    number = "414100000000000000",
+                    expDate = "1210"
+                },
+                customBilling = new customBilling { phone = "1112223333" },
+                orderChannel = orderChannelEnum.MIT
+            };
+            var response = _cnp.Authorize(authorization);
+
+            DateTime checkDate = new DateTime(0001, 1, 1, 00, 00, 00);
+
+            Assert.AreEqual("000", response.response);
+            Assert.AreEqual(checkDate, response.postDate);
+        }
+
+        [Test]
+        public void SimpleAuthWithSellerInfo()
+        {
+            var authorization = new authorization
+            {
+                id = "1",
+                reportGroup = "Planets",
+                orderId = "12344",
+                amount = 106,
+                orderSource = orderSourceType.ecommerce,
+                card = new cardType
+                {
+                    type = methodOfPaymentTypeEnum.VI,
+                    number = "414100000000000000",
+                    expDate = "1210"
+                },
+                customBilling = new customBilling { phone = "1112223333" },
+                sellerInfo = new sellerInfo
+                {
+                    accountNumber = "4485581000000005",
+                    aggregateOrderCount = 4,
+                    aggregateOrderDollars = 100000,
+                    sellerAddress = new sellerAddress
+                    {
+                        sellerStreetaddress = "15 Main Street",
+                        sellerUnit = "100 AB",
+                        sellerPostalcode = "12345",
+                        sellerCity = "San Jose",
+                        sellerProvincecode = "MA",
+                        sellerCountrycode = "US"
+                    },
+                    createdDate = "2015-11-12T20:33:09",
+                    domain = "vap",
+                    email = "bob@example.com",
+                    lastUpdateDate = "2015-11-12T20:33:09",
+                    name = "bob",
+                    onboardingEmail = "bob@example.com",
+                    onboardingIpAddress = "75.100.88.78",
+                    parentEntity = "abc",
+                    phone = "9785510040",
+                    sellerId = "123456789",
+                    sellerTags = new sellerTagsType
+                    {
+                     tag = "2"
+                    },
+                    username = "bob123"
+                }
+            };
+            var response = _cnp.Authorize(authorization);
+
+            DateTime checkDate = new DateTime(0001, 1, 1, 00, 00, 00);
+
+            Assert.AreEqual("000", response.response);
+            Assert.AreEqual(checkDate, response.postDate);
+        }
+
+        [Test]
+        public void SimpleAuthWithAuthIndicatorWithEstimatedEnum()
+        {
+            var authorization = new authorization
+            {
+                id = "1",
+                reportGroup = "Planets",
+                orderId = "12344",
+                amount = 106,
+                orderSource = orderSourceType.ecommerce,
+                authIndicator = authIndicatorEnum.Estimated,
+                card = new cardType
+                {
+                    type = methodOfPaymentTypeEnum.VI,
+                    number = "414100000000000000",
+                    expDate = "1210"
+                },
+                customBilling = new customBilling { phone = "1112223333" }
+            };
+            var response = _cnp.Authorize(authorization);
+
+            DateTime checkDate = new DateTime(0001, 1, 1, 00, 00, 00);
+
+            Assert.AreEqual("000", response.response);
+            Assert.AreEqual(checkDate, response.postDate);
+        }
+
+        [Test]
+        public void SimpleAuthWithAuthIndicatorWithIncreamentalEnum()
+        {
+            var authorization = new authorization
+            {
+                id = "1",
+                customerId = "CustId",
+                reportGroup = "Planets", 
+                cnpTxnId = 901097991325067135,
+                amount = 106,
+                authIndicator = authIndicatorEnum.Incremental,
+        
+            };
+            var response = _cnp.Authorize(authorization);
+
+            DateTime checkDate = new DateTime(0001, 1, 1, 00, 00, 00);
+
+            Assert.AreEqual("000", response.response);
+            Assert.AreEqual(checkDate, response.postDate);
+        }
+        //12.28,12.29 and 12.30 end
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestBatch.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestBatch.cs
@@ -1939,6 +1939,99 @@ namespace Cnp.Sdk.Test.Functional
             }
         }
 
+        // 12.28,12.29 and 12.30 start
+        [Test]
+        public void SimpleAuthSaleWithOrderchannelEnumMIT_SellerInfo_AuthIndicatorEstimatedEnum() //12.28 , 12.29 and 12.30
+        {
+            var cnpBatchRequest = new batchRequest();
+            var authorization = new authorization
+            {
+                id = new Random().Next(100).ToString(),
+                reportGroup = "Planets",
+                orderId = "12344",
+                amount = new Random().Next(1000),
+                orderSource = orderSourceType.ecommerce,
+                sellerInfo = new sellerInfo
+                {
+                    accountNumber = "4485581000000005",
+                    aggregateOrderCount = 4,
+                    aggregateOrderDollars = 100000,
+                    sellerAddress = new sellerAddress
+                    {
+                        sellerStreetaddress = "15 Main Street",
+                        sellerUnit = "100 AB",
+                        sellerPostalcode = "12345",
+                        sellerCity = "San Jose",
+                        sellerProvincecode = "MA",
+                        sellerCountrycode = "US"
+                    },
+                    createdDate = "2015-11-12T20:33:09",
+                    domain = "vap",
+                    email = "bob@example.com",
+                    lastUpdateDate = "2015-11-12T20:33:09",
+                    name = "bob",
+                    onboardingEmail = "bob@example.com",
+                    onboardingIpAddress = "75.100.88.78",
+                    parentEntity = "abc",
+                    phone = "9785510040",
+                    sellerId = "123456789",
+                    sellerTags = new sellerTagsType
+                    {
+                        tag = "2"
+                    },
+                    username = "bob123"
+
+                },
+                crypto = false,
+                orderChannel = orderChannelEnum.MIT,
+                fraudCheckStatus = "Not Approved",
+                card = new cardType
+                {
+                    type = methodOfPaymentTypeEnum.VI,
+                    number = "4100000000000001",
+                    expDate = "1223"
+
+                },
+
+                overridePolicy = "Override Policy",
+                fsErrorCode = "FS Error Code",
+                merchantAccountStatus = "Merchant Account Status",
+                productEnrolled = productEnrolledEnum.GUARPAY2,
+                decisionPurpose = decisionPurposeEnum.INFORMATION_ONLY,
+                fraudSwitchIndicator = fraudSwitchIndicatorEnum.PRE,
+                customBilling = new customBilling { phone = "1112223333" },
+                authIndicator = authIndicatorEnum.Estimated
+            };
+
+            cnpBatchRequest.addAuthorization(authorization);
+
+            _cnp.addBatch(cnpBatchRequest);
+
+            var batchName = _cnp.sendToCnp();
+
+            _cnp.blockAndWaitForResponse(batchName, estimatedResponseTime(2 * 2, 10 * 2));
+
+            var cnpResponse = _cnp.receiveFromCnp(batchName);
+
+            Assert.NotNull(cnpResponse);
+            Assert.AreEqual("0", cnpResponse.response);
+            Assert.AreEqual("Valid Format", cnpResponse.message);
+
+            var cnpBatchResponse = cnpResponse.nextBatchResponse();
+            while (cnpBatchResponse != null)
+            {
+                var authResponse = cnpBatchResponse.nextAuthorizationResponse();
+                while (authResponse != null)
+                {
+                    Assert.AreEqual("000", authResponse.response);
+
+                    authResponse = cnpBatchResponse.nextAuthorizationResponse();
+                }
+                cnpBatchResponse = cnpResponse.nextBatchResponse();
+            }
+        }
+        // 12.28,12.29 and 12.30 end
+
         private int estimatedResponseTime(int numAuthsAndSales, int numRest)
         {
             return (int)(5 * 60 * 1000 + 2.5 * 1000 + numAuthsAndSales * (1 / 5) * 1000 + numRest * (1 / 50) * 1000) * 5;

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestSale.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestSale.cs
@@ -835,5 +835,88 @@ namespace Cnp.Sdk.Test.Functional
             Assert.AreEqual(false, responseObj.authMax.authMaxApplied);
             StringAssert.AreEqualIgnoringCase("Approved", responseObj.message);
         }
+
+        [Test]
+        public void SimpleSaleWithOrdChanelEnumMIT() //12.28
+        {
+            var saleObj = new sale
+            {
+                id = "1",
+                reportGroup = "Planets",
+                orderId = "12344",
+                amount = 106,
+                orderSource = orderSourceType.ecommerce,
+                crypto = false,
+                orderChannel = orderChannelEnum.MIT,
+                fraudCheckStatus = "Not Approved",
+                card = new cardType
+                {
+                    type = methodOfPaymentTypeEnum.VI,
+                    number = "414100000000000000",
+                    expDate = "1210"
+                },
+                overridePolicy = "Override Policy",
+                fsErrorCode = "FS Error Code",
+                merchantAccountStatus = "Merchant Account Status",
+                productEnrolled = productEnrolledEnum.GUARPAY2,
+                decisionPurpose = decisionPurposeEnum.INFORMATION_ONLY,
+                fraudSwitchIndicator = fraudSwitchIndicatorEnum.PRE,
+                customBilling = new customBilling { phone = "1112223333" }
+            };
+            var responseObj = _cnp.Sale(saleObj);
+            StringAssert.AreEqualIgnoringCase("Approved", responseObj.message);
+        }
+
+        [Test]
+        public void SimpleSaleWithSellerInfo() //12.29
+        {
+            var saleObj = new sale
+            {
+                id = "1",
+                amount = 106,
+                cnpTxnId = 123456,
+                orderId = "12344",
+                orderSource = orderSourceType.ecommerce,
+                card = new cardType
+                {
+                    type = methodOfPaymentTypeEnum.VI,
+                    number = "414100000000000000",
+                    expDate = "1210"
+                },
+                sellerInfo = new sellerInfo
+                {
+                    accountNumber = "4485581000000005",
+                    aggregateOrderCount = 4,
+                    aggregateOrderDollars = 100000,
+                    sellerAddress = new sellerAddress
+                    {
+                        sellerStreetaddress = "15 Main Street",
+                        sellerUnit = "100 AB",
+                        sellerPostalcode = "12345",
+                        sellerCity = "San Jose",
+                        sellerProvincecode = "MA",
+                        sellerCountrycode = "US"
+                    },
+                    createdDate = "2015-11-12T20:33:09",
+                    domain = "vap",
+                    email = "bob@example.com",
+                    lastUpdateDate = "2015-11-12T20:33:09",
+                    name = "bob",
+                    onboardingEmail = "bob@example.com",
+                    onboardingIpAddress = "75.100.88.78",
+                    parentEntity = "abc",
+                    phone = "9785510040",
+                    sellerId = "123456789",
+                    sellerTags = new sellerTagsType
+                    {
+                        tag = "2"
+                    },
+                    username = "bob123"
+                
+                }
+            };
+            var responseObj = _cnp.Sale(saleObj);
+            StringAssert.AreEqualIgnoringCase("Approved", responseObj.message);
+        }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestAuthorization.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestAuthorization.cs
@@ -2,7 +2,6 @@
 using NUnit.Framework;
 using Moq;
 using System.Text.RegularExpressions;
-using System.Xml.Linq;
 
 
 namespace Cnp.Sdk.Test.Unit

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestAuthorization.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestAuthorization.cs
@@ -2,6 +2,7 @@
 using NUnit.Framework;
 using Moq;
 using System.Text.RegularExpressions;
+using System.Xml.Linq;
 
 
 namespace Cnp.Sdk.Test.Unit
@@ -892,5 +893,123 @@ namespace Cnp.Sdk.Test.Unit
             Assert.NotNull(authorizationResponse);
             Assert.AreEqual(123, authorizationResponse.cnpTxnId);
         }
+
+        // 12.28, 12.29 and 12.30 start
+        [Test]
+        public void AuthWithOrderchannelEnumMIT_SellerInfo_AuthIndicatorEstimatedEnum() 
+        {
+            var auth = new authorization();
+            auth.orderId = "12344";
+            auth.amount = 2;
+            auth.orderSource = orderSourceType.ecommerce;
+            var sellerInfo = new sellerInfo();
+            sellerInfo.accountNumber = "4485581000000005";
+            sellerInfo.aggregateOrderCount = 4;
+            sellerInfo.aggregateOrderDollars = 100000;
+            var sellerAddress = new sellerAddress();
+            sellerAddress.sellerStreetaddress = "15 Main Street";
+            sellerAddress.sellerUnit = "100 AB";
+            sellerAddress.sellerPostalcode = "12345";
+            sellerAddress.sellerCity = "San Jose";
+            sellerAddress.sellerProvincecode = "MA";
+            sellerAddress.sellerCountrycode = "US";
+            sellerInfo.sellerAddress = sellerAddress;
+            sellerInfo.createdDate = "2015-11-12T20:33:09";
+            sellerInfo.domain = "vap";
+            sellerInfo.email = "bob@example.com";
+            sellerInfo.lastUpdateDate = "2015-11-12T20:33:09";
+            sellerInfo.name = "bob";
+            sellerInfo.onboardingEmail = "bob@example.com";
+            sellerInfo.onboardingIpAddress = "75.100.88.78";
+            sellerInfo.parentEntity = "abc";
+            sellerInfo.phone = "9785510040";
+            sellerInfo.sellerId = "123456789";
+            var sellerTagsType = new sellerTagsType();
+            sellerTagsType.tag = "3";
+            sellerInfo.sellerTags = sellerTagsType;
+            sellerInfo.username = "bob123";
+            auth.sellerInfo = sellerInfo;
+            auth.reportGroup = "Planets";
+            auth.id = "thisisid";
+            auth.businessIndicator = businessIndicatorEnum.fundTransfer;
+            auth.orderChannel = orderChannelEnum.MIT;
+            auth.crypto = false;
+            auth.fraudCheckStatus = "Not Approved";
+            var passengerTransportData = new passengerTransportData();
+            passengerTransportData.passengerName = "Pia Jaiswal";
+            passengerTransportData.ticketNumber = "TR0001";
+            passengerTransportData.issuingCarrier = "IC";
+            passengerTransportData.carrierName = "Indigo";
+            passengerTransportData.restrictedTicketIndicator = "TI2022";
+            passengerTransportData.numberOfAdults = 1;
+            passengerTransportData.numberOfChildren = 1;
+            passengerTransportData.customerCode = "C2011583";
+            passengerTransportData.arrivalDate = new System.DateTime(2022, 12, 31);
+            passengerTransportData.issueDate = new System.DateTime(2022, 12, 25);
+            passengerTransportData.travelAgencyCode = "TAC12345";
+            passengerTransportData.travelAgencyName = "Yatra";
+            passengerTransportData.computerizedReservationSystem = computerizedReservationSystemEnum.STRT;
+            passengerTransportData.creditReasonIndicator = creditReasonIndicatorEnum.A;
+            passengerTransportData.ticketChangeIndicator = ticketChangeIndicatorEnum.C;
+            passengerTransportData.ticketIssuerAddress = "Hinjewadi";
+            passengerTransportData.exchangeTicketNumber = "ETN12345";
+            passengerTransportData.exchangeAmount = 12300;
+            passengerTransportData.exchangeFeeAmount = 11000;
+
+            var tripLegData = new tripLegData();
+            tripLegData.tripLegNumber = 12;
+            tripLegData.departureCode = "DC";
+            tripLegData.carrierCode = "CC";
+            tripLegData.serviceClass = serviceClassEnum.First;
+            tripLegData.stopOverCode = "N";
+            tripLegData.destinationCode = "DC111";
+            tripLegData.fareBasisCode = "FBC12345";
+            tripLegData.departureDate = new System.DateTime(2023, 1, 31);
+            tripLegData.originCity = "Pune";
+            tripLegData.travelNumber = "TN111";
+            tripLegData.departureTime = "13:05";
+            tripLegData.arrivalTime = "16:10";
+            tripLegData.remarks = "NA";
+            passengerTransportData.tripLegData = tripLegData;
+            auth.passengerTransportData = passengerTransportData;
+            auth.authIndicator = authIndicatorEnum.Estimated;
+
+            var mock = new Mock<Communications>();
+
+            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<accountNumber>4485581000000005</accountNumber>.*<aggregateOrderCount>4</aggregateOrderCount>.*<aggregateOrderDollars>100000</aggregateOrderDollars>.*", RegexOptions.Singleline)))
+                .Returns("<cnpOnlineResponse version='12.30' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><authorizationResponse><cnpTxnId>123</cnpTxnId></authorizationResponse></cnpOnlineResponse>");
+
+            var mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            var authorizationResponse = cnp.Authorize(auth);
+
+            Assert.NotNull(authorizationResponse);
+            Assert.AreEqual(123, authorizationResponse.cnpTxnId);
+        }
+
+        [Test]
+        public void AuthWithAuthIndicatorIncrementalEnum()
+        {
+            var auth = new authorization();
+            auth.id = "thisisid";
+            auth.customerId = "Cust044";
+            auth.reportGroup = "Planets";
+            auth.cnpTxnId = 12345;
+            auth.amount = 5000;
+            auth.authIndicator = authIndicatorEnum.Incremental;
+            var mock = new Mock<Communications>();
+            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<cnpTxnId>12345</cnpTxnId>.*<amount>5000</amount>.*", RegexOptions.Singleline)))
+               .Returns("<cnpOnlineResponse version='12.30' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><authorizationResponse><cnpTxnId>123</cnpTxnId></authorizationResponse></cnpOnlineResponse>");
+
+            var mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            var authorizationResponse = cnp.Authorize(auth);
+
+            Assert.NotNull(authorizationResponse);
+            Assert.AreEqual(123, authorizationResponse.cnpTxnId);
+
+        }
+        // 12.28, 12.29 and 12.30 end
+
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestSale.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestSale.cs
@@ -700,5 +700,97 @@ namespace Cnp.Sdk.Test.Unit
             Assert.NotNull(response);
             Assert.AreEqual("sandbox", response.location);
         }
+
+        [Test]
+        public void TestSaleWithOrderchannelEnumMIT_SellerInfo() //new testcase for 12.28 and 12.29
+        {
+            sale sale = new sale();
+            sale.orderId = "12344";
+            sale.amount = 2;
+            sale.orderSource = orderSourceType.ecommerce;
+            var sellerInfo = new sellerInfo();
+            sellerInfo.accountNumber = "4485581000000005";
+            sellerInfo.aggregateOrderCount = 4;
+            sellerInfo.aggregateOrderDollars = 100000;
+            var sellerAddress = new sellerAddress();
+            sellerAddress.sellerStreetaddress = "15 Main Street";
+            sellerAddress.sellerUnit = "100 AB";
+            sellerAddress.sellerPostalcode = "12345";
+            sellerAddress.sellerCity = "San Jose";
+            sellerAddress.sellerProvincecode = "MA";
+            sellerAddress.sellerCountrycode = "US";
+            sellerInfo.sellerAddress = sellerAddress;
+            sellerInfo.createdDate = "2015-11-12T20:33:09";
+            sellerInfo.domain = "vap";
+            sellerInfo.email = "bob@example.com";
+            sellerInfo.lastUpdateDate = "2015-11-12T20:33:09";
+            sellerInfo.name = "bob";
+            sellerInfo.onboardingEmail = "bob@example.com";
+            sellerInfo.onboardingIpAddress = "75.100.88.78";
+            sellerInfo.parentEntity = "abc";
+            sellerInfo.phone = "9785510040";
+            sellerInfo.sellerId = "123456789";
+            var sellerTagsType = new sellerTagsType();
+            sellerTagsType.tag = "3";
+            sellerInfo.sellerTags = sellerTagsType;
+            sellerInfo.username = "bob123";
+            sale.sellerInfo = sellerInfo;
+            sale.reportGroup = "Planets";
+            sale.id = "thisisid";
+            sale.businessIndicator = businessIndicatorEnum.fundTransfer;
+            sale.crypto = false;
+            sale.orderChannel = orderChannelEnum.MIT;
+            sale.fraudCheckStatus = "Not Approved";
+
+            var passengerTransportData = new passengerTransportData();
+            passengerTransportData.passengerName = "Pia Jaiswal";
+            passengerTransportData.ticketNumber = "TR0001";
+            passengerTransportData.issuingCarrier = "IC";
+            passengerTransportData.carrierName = "Indigo";
+            passengerTransportData.restrictedTicketIndicator = "TI2022";
+            passengerTransportData.numberOfAdults = 1;
+            passengerTransportData.numberOfChildren = 1;
+            passengerTransportData.customerCode = "C2011583";
+            passengerTransportData.arrivalDate = new System.DateTime(2022, 12, 31);
+            passengerTransportData.issueDate = new System.DateTime(2022, 12, 25);
+            passengerTransportData.travelAgencyCode = "TAC12345";
+            passengerTransportData.travelAgencyName = "Yatra";
+            passengerTransportData.computerizedReservationSystem = computerizedReservationSystemEnum.STRT;
+            passengerTransportData.creditReasonIndicator = creditReasonIndicatorEnum.A;
+            passengerTransportData.ticketChangeIndicator = ticketChangeIndicatorEnum.C;
+            passengerTransportData.ticketIssuerAddress = "Hinjewadi";
+            passengerTransportData.exchangeTicketNumber = "ETN12345";
+            passengerTransportData.exchangeAmount = 12300;
+            passengerTransportData.exchangeFeeAmount = 11000;
+
+            var tripLegData = new tripLegData();
+            tripLegData.tripLegNumber = 12;
+            tripLegData.departureCode = "DC";
+            tripLegData.carrierCode = "CC";
+            tripLegData.serviceClass = serviceClassEnum.First;
+            tripLegData.stopOverCode = "N";
+            tripLegData.destinationCode = "DC111";
+            tripLegData.fareBasisCode = "FBC12345";
+            tripLegData.departureDate = new System.DateTime(2023, 1, 31);
+            tripLegData.originCity = "Pune";
+            tripLegData.travelNumber = "TN111";
+            tripLegData.departureTime = "13:05";
+            tripLegData.arrivalTime = "16:10";
+            tripLegData.remarks = "NA";
+            passengerTransportData.tripLegData = tripLegData;
+            sale.passengerTransportData = passengerTransportData;
+
+            var mock = new Mock<Communications>();
+
+            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<accountNumber>4485581000000005</accountNumber>.*<aggregateOrderCount>4</aggregateOrderCount>.*<aggregateOrderDollars>100000</aggregateOrderDollars>.*", RegexOptions.Singleline)))
+                .Returns("<cnpOnlineResponse version='12.30' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><saleResponse><cnpTxnId>123</cnpTxnId><location>sandbox</location></saleResponse></cnpOnlineResponse>");
+
+            var mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            var response = cnp.Sale(sale);
+
+            Assert.NotNull(response);
+            Assert.AreEqual("sandbox", response.location);
+        }
     }
 }


### PR DESCRIPTION
- Change: [cnpAPI v12.28] New value MIT added in existing enum order channel.

- Change: [cnpAPI v12.29] New element sellerInfo added in Authorization and sale Request.

- Change: [cnpAPI v12.29] New elements accountNumber, aggregateOrderCount, aggregateOrderDollars, sellerAddress, createdDate, domain, email,lastUpdateDate, name, onboardingEmail, onboardingIpAddress, parentEntity, phone, sellerId,
sellerTags and username added in sellerInfo.

- Change: [cnpAPI v12.29] New elements sellerStreetaddress, sellerUnit, sellerPostalcode, sellerCity, sellerProvincecode
and sellerCountrycode added in sellerAddress.

- Change: [cnpAPI v12.29] The datatype for networkToken, authMaxResponseCode, authMaxResponseMessage has been changed.

- Change: [cnpAPI v12.30] New element authIndicator added in Authorization Request.

- Change: [cnpAPI v12.30] New element amount added in Authorization Request.

- Change: [cnpAPI v12.30] To support authIndicator new enum authIndicatorEnum added with values Incremental and Estimated .