### PR TITLE
Promoting changes to upgrade 'SSH.NET'

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 
 = Worldpay CNP CHANGELOG
+==Change Log for 12.40.1(November 08,2024)
+* Change: [cnpAPI v12.40.1] Changing Renci.SshNet library version from 2016.1.0 to 2020.0.2
+
 ==Change Log for 12.40(October 16,2024)
 * Change: [cnpAPI v12.40] In authorization,sale and captureGivenAuth request new elements added-> 'typeOfDigitalCurrency' and 'conversionAffiliateId'.
 * Change: [cnpAPI v12.40] In existing simple type transactionAmountType range added between minInclusive value -999999999999  and maxInclusive value 999999999999

--- a/CnpSdkForNet/CnpSdkForNet/CnpSdkForNet.csproj
+++ b/CnpSdkForNet/CnpSdkForNet/CnpSdkForNet.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>dotNetSDKKey.snk</AssemblyOriginatorKeyFile>
-        <PackageVersion>12.40.0</PackageVersion>
+        <PackageVersion>12.40.1</PackageVersion>
         <Title>Vantiv.CnpSdkForNet</Title>
         <Authors>FIS</Authors>
         <Copyright>Copyright © FIS 2020</Copyright>
@@ -20,7 +20,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="SSH.NET" Version="2016.1.0" />
+      <PackageReference Include="SSH.NET" Version="2020.0.2" />
       <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
       <PackageReference Include="System.Net.Http" Version="4.3.4" />
     </ItemGroup>

--- a/CnpSdkForNet/CnpSdkForNet/CnpVersion.cs
+++ b/CnpSdkForNet/CnpSdkForNet/CnpVersion.cs
@@ -8,7 +8,7 @@ namespace Cnp.Sdk
      */
     public class CnpVersion
     {
-        public const String CurrentCNPXMLVersion = "12.40";
-        public const String CurrentCNPSDKVersion = "12.40.0";
+        public const String CurrentCNPXMLVersion = "12.40.1";
+        public const String CurrentCNPSDKVersion = "12.40.1";
     }
 }


### PR DESCRIPTION
* Changing Renci.SshNet library version from 2016.1.0 to 2020.0.2