### PR TITLE
SDK v12.44

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,25 @@
 
 = Worldpay CNP CHANGELOG
 
+==Change Log for 12.44 (March 19,2025)
+* Change: [cnpAPI v12.44] In ordersourcetype enum, 'ecommerceDataOnly' value is added.
+ 
+==Change Log for 12.43 [Only for Worldpay Internal Usage]
+* Change: [cnpAPI v12.43] Two new elements cumulativeAmount,originalTransactionAmount added in realtimeIncrementalAuthorization.
+* Change: [cnpAPI v12.43] In enum networkFieldNameEnumType,'Additional Request Data' value is added.
+ 
+==Change Log for 12.42 [Only for Worldpay Internal Usage]
+* Change: [cnpAPI v12.42] For all child elements of identityBundle minOccurs changed to 0 from 1.
+* Change: [cnpAPI v12.42] New Transaction type realtimeIncrementalAuthorization added.
+* Change: [cnpAPI v12.42] New element originalRetrievalReferenceNumber added in authorization request.
+ 
+==Change Log for 12.41
+* Change: [cnpAPI v12.41] In authorization,authReversal,capture,sale,credit,depositTransactionReversal,refundTransactionReversal new complex type element added - identityBundle.
+* Change: [cnpAPI v12.41] New complex type element identityBundle with child elements-merchantId,entityId,entityReference,resourceId,resourceReference,commandId,commandReference,orderReference with minOccurs as 1.
+* Change: [cnpAPI v12.41] New elements are added in authorizationResponse,saleResponse -retrievalReferenceNumber of type string12Type ,orderSource of type orderSourceType.
+* Change: [cnpAPI v12.41] New datatype- string12Type - of string type of length 12 to support retrievalReferenceNumber element .
+* Change: [cnpAPI v12.41] For existing element cardSuffixType maxLength is increased to 23
+
 ==Change Log for 12.40.2(November 19,2024)
 * Change: [cnpAPI v12.40.2] Changed bydefault value of payloadTobeEncrypted as false.
 * Change: [cnpAPI v12.40.2] Removed unsafe access for payloadTobeEncrypted and oltpEncryptionKeySequence.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,13 +4,13 @@
 ==Change Log for 12.44 (March 19,2025)
 * Change: [cnpAPI v12.44] In ordersourcetype enum, 'ecommerceDataOnly' value is added.
  
-==Change Log for 12.43 [Only for Worldpay Internal Usage]
-* Change: [cnpAPI v12.43] Two new elements cumulativeAmount,originalTransactionAmount added in realtimeIncrementalAuthorization.
+==Change Log for 12.43
+* Change: [cnpAPI v12.43] Two new elements cumulativeAmount,originalTransactionAmount added in realtimeIncrementalAuthorization. [Only for Worldpay Internal Usage]
 * Change: [cnpAPI v12.43] In enum networkFieldNameEnumType,'Additional Request Data' value is added.
  
-==Change Log for 12.42 [Only for Worldpay Internal Usage]
+==Change Log for 12.42
 * Change: [cnpAPI v12.42] For all child elements of identityBundle minOccurs changed to 0 from 1.
-* Change: [cnpAPI v12.42] New Transaction type realtimeIncrementalAuthorization added.
+* Change: [cnpAPI v12.42] New Transaction type realtimeIncrementalAuthorization added.   [Only for Worldpay Internal Usage]
 * Change: [cnpAPI v12.42] New element originalRetrievalReferenceNumber added in authorization request.
  
 ==Change Log for 12.41

--- a/CnpSdkForNet/CnpSdkForNet/CnpBatchRequest.cs
+++ b/CnpSdkForNet/CnpSdkForNet/CnpBatchRequest.cs
@@ -667,6 +667,21 @@ namespace Cnp.Sdk
             }
         }
 
+        public void addRealTimeIncrementalAuthorization(realtimeIncrementalAuthorization realTimeIncAuth)
+        {
+            if (numAccountUpdates == 0)
+            {
+                numAuthorization++;
+                sumOfAuthorization += realTimeIncAuth.amount;
+                fillInReportGroup(realTimeIncAuth);
+                tempBatchFilePath = saveElement(cnpFile, cnpTime, tempBatchFilePath, realTimeIncAuth);
+            }
+            else
+            {
+                throw new CnpOnlineException(accountUpdateErrorMessage);
+            }
+        }
+
         public void addCapture(capture capture)
         {
             if (numAccountUpdates == 0)

--- a/CnpSdkForNet/CnpSdkForNet/CnpOnline.cs
+++ b/CnpSdkForNet/CnpSdkForNet/CnpOnline.cs
@@ -93,6 +93,15 @@ namespace Cnp.Sdk
             }, auth, cancellationToken);
         }
 
+        public Task<authorizationResponse> realTimeIncAuthAsync(realtimeIncrementalAuthorization realTimeIncAuth, CancellationToken cancellationToken)
+        {
+            return SendRequestAsync(response =>
+            {
+                var authResponse = response.authorizationResponse;
+                return authResponse;
+            }, realTimeIncAuth, cancellationToken);
+        }
+
         private T SendRequest<T>(Func<cnpOnlineResponse, T> getResponse, transactionRequest transaction)
         {
             cnpOnlineResponse response;
@@ -392,6 +401,10 @@ namespace Cnp.Sdk
             {
                 request.encryptionKeyRequest = (EncryptionKeyRequest)transaction;
             }
+            else if (transaction is realtimeIncrementalAuthorization)
+            {
+                request.realtimeIncrementalAuthorization = (realtimeIncrementalAuthorization)transaction;
+            }
             else
             {
                 throw new NotImplementedException("Support for type: " + transaction.GetType().Name +
@@ -403,6 +416,13 @@ namespace Cnp.Sdk
         public authorizationResponse Authorize(authorization auth)
         {
             var cnpResponse =  SendRequest(response => response, auth);
+            var authResponse = cnpResponse.authorizationResponse;
+            return authResponse;
+        }
+
+        public authorizationResponse realtimeIncrementalAuth(realtimeIncrementalAuthorization RealTimeIncAuth)
+        {
+            var cnpResponse = SendRequest(response => response, RealTimeIncAuth);
             var authResponse = cnpResponse.authorizationResponse;
             return authResponse;
         }
@@ -1492,6 +1512,8 @@ namespace Cnp.Sdk
     {
         authorizationResponse Authorize(authorization auth);
         Task<authorizationResponse> AuthorizeAsync(authorization auth, CancellationToken cancellationToken);
+        authorizationResponse realtimeIncrementalAuth(realtimeIncrementalAuthorization realTimeInceAuth);
+        Task<authorizationResponse> realTimeIncAuthAsync(realtimeIncrementalAuthorization realTimeInceAuth, CancellationToken cancellationToken);
         authReversalResponse AuthReversal(authReversal reversal);
         Task<authReversalResponse> AuthReversalAsync(authReversal reversal, CancellationToken cancellationToken);
         captureResponse Capture(capture capture);

--- a/CnpSdkForNet/CnpSdkForNet/CnpSdkForNet.csproj
+++ b/CnpSdkForNet/CnpSdkForNet/CnpSdkForNet.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>dotNetSDKKey.snk</AssemblyOriginatorKeyFile>
-        <PackageVersion>12.40.2</PackageVersion>
+        <PackageVersion>12.44.0</PackageVersion>
         <Title>Vantiv.CnpSdkForNet</Title>
         <Authors>FIS</Authors>
         <Copyright>Copyright © FIS 2020</Copyright>

--- a/CnpSdkForNet/CnpSdkForNet/CnpVersion.cs
+++ b/CnpSdkForNet/CnpSdkForNet/CnpVersion.cs
@@ -8,7 +8,7 @@ namespace Cnp.Sdk
      */
     public class CnpVersion
     {
-        public const String CurrentCNPXMLVersion = "12.40";
-        public const String CurrentCNPSDKVersion = "12.40.2";
+        public const String CurrentCNPXMLVersion = "12.44";
+        public const String CurrentCNPSDKVersion = "12.44.0";
     }
 }

--- a/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
+++ b/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
@@ -75,6 +75,7 @@ namespace Cnp.Sdk
         public updateSubscription updateSubscription;
         public voidTxn voidTxn;
         public translateToLowValueTokenRequest translateToLowValueTokenRequest;
+        public realtimeIncrementalAuthorization realtimeIncrementalAuthorization;
 
         // Serialize the cnpOnlineRequest.
         // Convert the cnpOnlineRequest object to xml string.
@@ -148,6 +149,7 @@ namespace Cnp.Sdk
             else if (BNPLCancelRequest != null) xml += BNPLCancelRequest.Serialize();
             else if (BNPLInquiryRequest != null) xml += BNPLInquiryRequest.Serialize();
             else if (encryptionKeyRequest != null) xml += encryptionKeyRequest.Serialize();
+            else if (realtimeIncrementalAuthorization != null) xml += realtimeIncrementalAuthorization.Serialize();
             xml += "\r\n</cnpOnlineRequest>";
 
             return xml;
@@ -618,7 +620,9 @@ namespace Cnp.Sdk
             }
         }
 
-        public identityBundle identityBundle;
+        public identityBundle identityBundle;  //12.41
+        public string originalRetrievalReferenceNumber;  //12.42
+
         public override string Serialize()
         {
             var xml = "\r\n<authorization";
@@ -857,6 +861,14 @@ namespace Cnp.Sdk
                 {
                     xml += "\r\n<conversionAffiliateId>" + conversionAffiliateIdField + "</conversionAffiliateId>";
                 }
+                if (identityBundle != null) //12.41
+                {
+                    xml += "\r\n<identityBundle>" + identityBundle.Serialize() + "\r\n</identityBundle>"; 
+                }
+                if (originalRetrievalReferenceNumber != null) //12.42
+                {
+                    xml += "\r\n<originalRetrievalReferenceNumber>" + originalRetrievalReferenceNumber + "</originalRetrievalReferenceNumber>"; 
+                }
             }
 
             xml += "\r\n</authorization>";
@@ -885,6 +897,8 @@ namespace Cnp.Sdk
         public string payPalNotes;
         public string actionReason;
         public additionalCOFData additionalCOFData;//12.26
+        //12.41 identityBundle
+        public identityBundle identityBundle;
 
         public override string Serialize()
         {
@@ -912,6 +926,10 @@ namespace Cnp.Sdk
             if (additionalCOFData != null)///12.26
             {
                 xml += "\r\n<additionalCOFData>" + additionalCOFData.Serialize() + "\r\n</additionalCOFData>";
+            }
+            if (identityBundle != null)  //12.41
+            {
+                xml += "\r\n<identityBundle>" + identityBundle.Serialize() + "</identityBundle>";
             }
             xml += "\r\n</authReversal>";
             return xml;
@@ -980,6 +998,8 @@ namespace Cnp.Sdk
         }
 
         public passengerTransportData passengerTransportData;//12.26
+        //12.41 identityBundle
+        public identityBundle identityBundle;
 
         public override string Serialize()
         {
@@ -1028,6 +1048,10 @@ namespace Cnp.Sdk
             if (passengerTransportData != null)//12.26
             {
                 xml += "\r\n<passengerTransportData>" + passengerTransportData.Serialize() + "</passengerTransportData>";
+            }
+            if (identityBundle != null)  //12.41
+            {
+                xml += "\r\n<identityBundle>" + identityBundle.Serialize() + "</identityBundle>";
             }
             xml += "\r\n</depositTransactionReversal>";
             return xml;
@@ -1095,6 +1119,8 @@ namespace Cnp.Sdk
         }
 
         public passengerTransportData passengerTransportData;//12.26
+        //12.41 identityBundle
+        public identityBundle identityBundle;
 
         public override string Serialize()
         {
@@ -1143,6 +1169,10 @@ namespace Cnp.Sdk
             if (passengerTransportData != null)//12.26
             {
                 xml += "\r\n<passengerTransportData>" + passengerTransportData.Serialize() + "</passengerTransportData>";
+            }
+            if (identityBundle != null)  //12.41
+            {
+                xml += "\r\n<identityBundle>" + identityBundle.Serialize() + "</identityBundle>";
             }
             xml += "\r\n</refundTransactionReversal>";
             return xml;
@@ -1244,6 +1274,8 @@ namespace Cnp.Sdk
         }
         public partialCapture partialCapture; //12.38
         //12.31 end
+        //12.41 identityBundle
+        public identityBundle identityBundle;
 
         public override string Serialize()
         {
@@ -1284,6 +1316,10 @@ namespace Cnp.Sdk
             if (partialCapture != null)//12.38
             {
                 xml += "\r\n<partialCapture>" + partialCapture.Serialize() + "\r\n</partialCapture>";
+            }
+            if (identityBundle != null)  //12.41
+            {
+                xml += "\r\n<identityBundle>" + identityBundle.Serialize() + "</identityBundle>";
             }
             xml += "\r\n</capture>";
 
@@ -1736,6 +1772,8 @@ namespace Cnp.Sdk
         public string payPalNotes;
         public string actionReason;
         public accountFundingTransactionData accountFundingTransactionData;
+        //12.41 identityBundle
+        public identityBundle identityBundle;
         public override string Serialize()
         {
             var xml = "\r\n<credit";
@@ -1817,6 +1855,10 @@ namespace Cnp.Sdk
             if (accountFundingTransactionData != null)
             {
                 xml += "\r\n<accountFundingTransactionData>" + accountFundingTransactionData.Serialize() + "\r\n</accountFundingTransactionData>";
+            }
+            if (identityBundle != null)  //12.41
+            {
+                xml += "\r\n<identityBundle>" + identityBundle.Serialize() + "</identityBundle>";
             }
             xml += "\r\n</credit>";
             return xml;
@@ -3147,6 +3189,8 @@ namespace Cnp.Sdk
             }
         }
 
+        //12.41 identityBundle
+        public identityBundle identityBundle;
 
         public override string Serialize()
         {
@@ -3390,17 +3434,21 @@ namespace Cnp.Sdk
             {
                 xml += "\r\n<conversionAffiliateId>" + conversionAffiliateIdField + "</conversionAffiliateId>";
             }
-        //end
-        //if (routingPreferenceSet)
-        //{
-        //    var routingPreferenceName = routingPreferenceField.ToString();
-        //    var attributes = 
-        //        (XmlEnumAttribute[])typeof(echeckAccountTypeEnum).GetMember(routingPreferenceField.ToString())[0].GetCustomAttributes(typeof(XmlEnumAttribute), false);
-        //    if (attributes.Length > 0) routingPreferenceName = attributes[0].Name;
-        //    xml += "\r\n<routingPreference>" + routingPreferenceName + "</routingPreference>";
-        //}
+            if (identityBundle != null) //12.41
+            {
+                xml += "\r\n<identityBundle>" + identityBundle.Serialize() + "</identityBundle>";
+            }
+            //end
+            //if (routingPreferenceSet)
+            //{
+            //    var routingPreferenceName = routingPreferenceField.ToString();
+            //    var attributes = 
+            //        (XmlEnumAttribute[])typeof(echeckAccountTypeEnum).GetMember(routingPreferenceField.ToString())[0].GetCustomAttributes(typeof(XmlEnumAttribute), false);
+            //    if (attributes.Length > 0) routingPreferenceName = attributes[0].Name;
+            //    xml += "\r\n<routingPreference>" + routingPreferenceName + "</routingPreference>";
+            //}
 
-        xml += "\r\n</sale>";
+            xml += "\r\n</sale>";
             return xml;
         }
     }
@@ -5833,11 +5881,16 @@ namespace Cnp.Sdk
         public static readonly orderSourceType recurringtel = new orderSourceType("recurringtel");
         public static readonly orderSourceType echeckppd = new orderSourceType("echeckppd");
         public static readonly orderSourceType applepay = new orderSourceType("applepay");
-        public static readonly orderSourceType androidpay = new orderSourceType("androidpay");
-
+        public static readonly orderSourceType androidpay = new orderSourceType("androidpay"); 
+        public static readonly orderSourceType ecommerceDataOnly = new orderSourceType("ecommerceDataOnly");  //12.44
         private orderSourceType(string value) { this.value = value; }
         public string Serialize() { return value; }
         private string value;
+
+        //adding non parameterized constructor to make deserialize work  for ordersource-added in authorizationResponse and saleResponse.
+        public orderSourceType()
+        {
+        }
     }
 
     public partial class contact
@@ -7749,6 +7802,211 @@ namespace Cnp.Sdk
         }
     }
 
+    public partial class realtimeIncrementalAuthorization : transactionTypeWithReportGroup
+    {
+        private long cnpTxnIdField;
+        private bool cnpTxnIdSet;
+        public long cnpTxnId
+        {
+            get
+            {
+                return cnpTxnIdField;
+            }
+            set
+            {
+                cnpTxnIdField = value;
+                cnpTxnIdSet = true;
+            }
+        }
+        public string orderId;
+        public long amount;
+        public orderSourceType orderSource;
+        public contact billToAddress;
+        public contact shipToAddress;
+        public cardType card;
+        public cardTokenType token;
+        public applepayType applepay;
+        public cardPaypageType paypage;
+        public fraudCheckType cardholderAuthentication;
+        public customBilling customBilling;
+        private bool allowPartialAuthField;
+        private bool allowPartialAuthSet;
+        public bool allowPartialAuth
+        {
+            get
+            {
+                return allowPartialAuthField;
+            }
+            set
+            {
+                allowPartialAuthField = value;
+                allowPartialAuthSet = true;
+            }
+        }
+
+        public wallet wallet;
+        private string originalNetworkTransactionIdField;
+        private bool originalNetworkTransactionIdSet;
+        public string originalNetworkTransactionId
+        {
+            get
+            {
+                return originalNetworkTransactionIdField;
+            }
+            set
+            {
+                originalNetworkTransactionIdField = value;
+                originalNetworkTransactionIdSet = true;
+            }
+        }
+        public string merchantCategoryCode;
+        public string originalRetrievalReferenceNumber;
+        public long cumulativeAmountField;
+        public bool cumulativeAmountSet;
+        public long cumulativeAmount
+        {
+            get
+            {
+                return cumulativeAmountField;
+            }
+            set
+            {
+                cumulativeAmountField = value;
+                cumulativeAmountSet = true;
+            }
+        }
+
+        private long originalTransactionAmountField;
+        private bool originalTransactionAmountSet;
+        public long originalTransactionAmount
+        {
+            get
+            {
+                return originalTransactionAmountField;
+            }
+            set
+            {
+                originalTransactionAmountField = value;
+                originalTransactionAmountSet = true;
+            }
+        }
+
+        public override string Serialize()
+        {
+            var xml = "\r\n<realtimeIncrementalAuthorization";
+
+            xml += " id=\"" + SecurityElement.Escape(id) + "\"";
+            if (customerId != null)
+            {
+                xml += " customerId=\"" + SecurityElement.Escape(customerId) + "\"";
+            }
+            xml += " reportGroup=\"" + SecurityElement.Escape(reportGroup) + "\">";
+            if (cnpTxnIdSet)
+            {
+                xml += "\r\n<cnpTxnId>" + cnpTxnIdField + "</cnpTxnId>";
+            }
+            xml += "\r\n<orderId>" + SecurityElement.Escape(orderId) + "</orderId>";
+            xml += "\r\n<amount>" + amount + "</amount>";
+              
+            if (orderSource != null)
+            {
+                xml += "\r<orderSource>" + orderSource.Serialize() + "</orderSource>";
+            }
+            if (billToAddress != null)
+            {
+                xml += "\r\n<billToAddress>" + billToAddress.Serialize() + "\r\n</billToAddress>";
+            }
+            if (shipToAddress != null)
+            {
+                xml += "\r<shipToAddress>" + shipToAddress.Serialize() + "</shipToAddress>";
+            }
+            if (card != null)
+            {
+                xml += "\r\n<card>" + card.Serialize() + "\r\n</card>";
+            }
+            else if (token != null)
+            {
+                xml += "\r<token>" + token.Serialize() + "</token>";
+            }
+            else if (paypage != null)
+            {
+                xml += "\r<paypage>" + paypage.Serialize() + "</paypage>";
+            }
+            else if (applepay != null)
+            {
+                xml += "\r<applepay>" + applepay.Serialize() + "</applepay>";
+            }
+            if (cardholderAuthentication != null)
+            {
+                xml += "\r<cardholderAuthentication>" + cardholderAuthentication.Serialize() + "</cardholderAuthentication>";
+            }
+            if (customBilling != null)
+            {
+                xml += "\r<customBilling>" + customBilling.Serialize() + "</customBilling>";
+            }
+            if (allowPartialAuthSet)
+            {
+                xml += "\r\n<allowPartialAuth>" + allowPartialAuthField.ToString().ToLower() + "</allowPartialAuth>";
+            }
+            if (wallet != null)
+            {
+                xml += "\r\n<wallet>" + wallet.Serialize() + "\r\n</wallet>";
+            }
+            if (originalNetworkTransactionIdSet)
+            {
+                xml += "\r\n<originalNetworkTransactionId>" + originalNetworkTransactionId + "</originalNetworkTransactionId>";
+            }
+            if (!string.IsNullOrEmpty(merchantCategoryCode))
+            {
+                xml += "\r<merchantCategoryCode>" + merchantCategoryCode + "</merchantCategoryCode>";
+            }
+            if (!string.IsNullOrEmpty(originalRetrievalReferenceNumber))
+            {
+                xml += "\r\n<originalRetrievalReferenceNumber>" +originalRetrievalReferenceNumber + "</originalRetrievalReferenceNumber>";
+            }
+            if (cumulativeAmountSet)
+            {
+                xml += "\r\n<cumulativeAmount>" + cumulativeAmount + "</cumulativeAmount>";
+            }
+             if (originalTransactionAmountSet)
+            { 
+            xml += "\r\n<originalTransactionAmount>" + originalTransactionAmount + "</originalTransactionAmount>";
+            }
+            xml += "\r\n</realtimeIncrementalAuthorization>";
+            return xml;
+        }
+    }
+
+
+    //v12.41
+
+    public partial class identityBundle
+    {
+        public string merchantId;
+        public string entityId;
+        public string entityReference;
+        public string resourceId;
+        public string resourceReference;
+        public string commandId;
+        public string commandReference;
+        public string orderReference;
+
+        public string Serialize()
+        {
+            var xml = "";
+            xml += "\r\n<merchantId>" + merchantId + "</merchantId>";
+            xml += "\r\n<entityId>" + entityId + "</entityId>";
+            xml += "\r\n<entityReference>" + entityReference + "</entityReference>";
+            xml += "\r\n<resourceId>" + resourceId + "</resourceId>";
+            xml += "\r\n<resourceReference>" + resourceReference + "</resourceReference>";
+            xml += "\r\n<commandId>" + commandId + "</commandId>";
+            xml += "\r\n<commandReference>" + commandReference + "</commandReference>";
+            xml += "\r\n<orderReference>" + orderReference + "</orderReference>";
+
+            return xml;
+        }
+    }
+     
     public class XmlUtil
     {
         public static string toXsdDate(DateTime dateTime)

--- a/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
+++ b/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
@@ -75,6 +75,7 @@ namespace Cnp.Sdk
         public updateSubscription updateSubscription;
         public voidTxn voidTxn;
         public translateToLowValueTokenRequest translateToLowValueTokenRequest;
+        public realtimeIncrementalAuthorization realtimeIncrementalAuthorization;
 
         // Serialize the cnpOnlineRequest.
         // Convert the cnpOnlineRequest object to xml string.
@@ -148,6 +149,7 @@ namespace Cnp.Sdk
             else if (BNPLCancelRequest != null) xml += BNPLCancelRequest.Serialize();
             else if (BNPLInquiryRequest != null) xml += BNPLInquiryRequest.Serialize();
             else if (encryptionKeyRequest != null) xml += encryptionKeyRequest.Serialize();
+            else if (realtimeIncrementalAuthorization != null) xml += realtimeIncrementalAuthorization.Serialize();
             xml += "\r\n</cnpOnlineRequest>";
 
             return xml;
@@ -320,8 +322,8 @@ namespace Cnp.Sdk
             get { return taxTypeField; }
             set { taxTypeField = value; taxTypeSet = true; }
         }
-        
-        
+
+
         private businessIndicatorEnum businessIndicatorField;
         private bool businessIndicatorSet;
         public businessIndicatorEnum businessIndicator
@@ -329,9 +331,9 @@ namespace Cnp.Sdk
             get { return businessIndicatorField; }
             set { businessIndicatorField = value; businessIndicatorSet = true; }
         }
-        
-        
-        
+
+
+
         private processingType processingTypeField;
         private bool processingTypeSet;
         public processingType processingType
@@ -468,13 +470,13 @@ namespace Cnp.Sdk
         private bool overridePolicySet;
         public string overridePolicy
         {
-            get 
-            { 
-                return overridePolicyField; 
+            get
+            {
+                return overridePolicyField;
             }
-            set 
-            { 
-                overridePolicyField = value; 
+            set
+            {
+                overridePolicyField = value;
                 overridePolicySet = true;
             }
         }
@@ -482,9 +484,9 @@ namespace Cnp.Sdk
         private bool fsErrorCodeSet;
         public string fsErrorCode
         {
-            get 
-            { 
-                return fsErrorCodeField; 
+            get
+            {
+                return fsErrorCodeField;
             }
             set
             {
@@ -496,21 +498,23 @@ namespace Cnp.Sdk
         private bool merchantAccountStatusSet;
         public string merchantAccountStatus
         {
-            get 
-            { 
+            get
+            {
                 return merchantAccountStatusField;
             }
-            set { merchantAccountStatusField = value;
+            set
+            {
+                merchantAccountStatusField = value;
                 merchantAccountStatusSet = true;
-                }
+            }
         }
         private productEnrolledEnum productEnrolledField;
         private bool productEnrolledSet;
         public productEnrolledEnum productEnrolled
         {
-            get 
-            { 
-                return productEnrolledField; 
+            get
+            {
+                return productEnrolledField;
             }
             set
             {
@@ -522,8 +526,8 @@ namespace Cnp.Sdk
         private bool decisionPurposeSet;
         public decisionPurposeEnum decisionPurpose
         {
-            get 
-            { 
+            get
+            {
                 return decisionPurposeField;
             }
             set
@@ -536,9 +540,9 @@ namespace Cnp.Sdk
         private bool fraudSwitchIndicatorSet;
         public fraudSwitchIndicatorEnum fraudSwitchIndicator
         {
-            get 
-            { 
-                return fraudSwitchIndicatorField; 
+            get
+            {
+                return fraudSwitchIndicatorField;
             }
             set
             {
@@ -617,6 +621,9 @@ namespace Cnp.Sdk
                 conversionAffiliateIdSet = true;
             }
         }
+
+        public identityBundle identityBundle;  //12.41
+        public string originalRetrievalReferenceNumber;  //12.42
 
         public override string Serialize()
         {
@@ -754,7 +761,7 @@ namespace Cnp.Sdk
                 }
                 ///end
                 //12.25 and 12.26
-                if(overridePolicySet)
+                if (overridePolicySet)
                 {
                     xml += "\r\n<overridePolicy>" + overridePolicyField + "</overridePolicy>";
                 }
@@ -826,7 +833,8 @@ namespace Cnp.Sdk
                 {
                     xml += "\r\n<originalTransactionAmount>" + originalTransactionAmount + "</originalTransactionAmount>";
                 }
-                if (skipRealtimeAU != null) {
+                if (skipRealtimeAU != null)
+                {
                     xml += "\r\n<skipRealtimeAU>" + skipRealtimeAU.ToString().ToLower() + "</skipRealtimeAU>";
                 }
 
@@ -834,7 +842,7 @@ namespace Cnp.Sdk
                 {
                     xml += "\r\n<merchantCategoryCode>" + merchantCategoryCode + "</merchantCategoryCode>";
                 }
-                
+
                 if (businessIndicatorSet)
                 {
                     xml += "\r\n<businessIndicator>" + businessIndicatorField + "</businessIndicator>";
@@ -855,6 +863,14 @@ namespace Cnp.Sdk
                 if (conversionAffiliateIdSet)
                 {
                     xml += "\r\n<conversionAffiliateId>" + conversionAffiliateIdField + "</conversionAffiliateId>";
+                }
+                if (identityBundle != null) //12.41
+                {
+                    xml += "\r\n<identityBundle>" + identityBundle.Serialize() + "\r\n</identityBundle>";
+                }
+                if (originalRetrievalReferenceNumber != null) //12.42
+                {
+                    xml += "\r\n<originalRetrievalReferenceNumber>" + originalRetrievalReferenceNumber + "</originalRetrievalReferenceNumber>";
                 }
             }
 
@@ -884,6 +900,8 @@ namespace Cnp.Sdk
         public string payPalNotes;
         public string actionReason;
         public additionalCOFData additionalCOFData;//12.26
+        //12.41 identityBundle
+        public identityBundle identityBundle;
 
         public override string Serialize()
         {
@@ -911,6 +929,10 @@ namespace Cnp.Sdk
             if (additionalCOFData != null)///12.26
             {
                 xml += "\r\n<additionalCOFData>" + additionalCOFData.Serialize() + "\r\n</additionalCOFData>";
+            }
+            if (identityBundle != null)  //12.41
+            {
+                xml += "\r\n<identityBundle>" + identityBundle.Serialize() + "</identityBundle>";
             }
             xml += "\r\n</authReversal>";
             return xml;
@@ -979,6 +1001,8 @@ namespace Cnp.Sdk
         }
 
         public passengerTransportData passengerTransportData;//12.26
+        //12.41 identityBundle
+        public identityBundle identityBundle;
 
         public override string Serialize()
         {
@@ -1019,7 +1043,7 @@ namespace Cnp.Sdk
             {
                 xml += this.lodgingInfoField.Serialize();
             }
-            
+
             if (this.processingInstructionsIsSet)
             {
                 xml += this.processingInstructionsField.Serialize();
@@ -1027,6 +1051,10 @@ namespace Cnp.Sdk
             if (passengerTransportData != null)//12.26
             {
                 xml += "\r\n<passengerTransportData>" + passengerTransportData.Serialize() + "</passengerTransportData>";
+            }
+            if (identityBundle != null)  //12.41
+            {
+                xml += "\r\n<identityBundle>" + identityBundle.Serialize() + "</identityBundle>";
             }
             xml += "\r\n</depositTransactionReversal>";
             return xml;
@@ -1066,7 +1094,7 @@ namespace Cnp.Sdk
         }
 
         public enhancedData enhancedData;
-        
+
         private bool processingInstructionsIsSet;
         private processingInstructions processingInstructionsField;
         public processingInstructions processingInstructions
@@ -1094,6 +1122,8 @@ namespace Cnp.Sdk
         }
 
         public passengerTransportData passengerTransportData;//12.26
+        //12.41 identityBundle
+        public identityBundle identityBundle;
 
         public override string Serialize()
         {
@@ -1142,6 +1172,10 @@ namespace Cnp.Sdk
             if (passengerTransportData != null)//12.26
             {
                 xml += "\r\n<passengerTransportData>" + passengerTransportData.Serialize() + "</passengerTransportData>";
+            }
+            if (identityBundle != null)  //12.41
+            {
+                xml += "\r\n<identityBundle>" + identityBundle.Serialize() + "</identityBundle>";
             }
             xml += "\r\n</refundTransactionReversal>";
             return xml;
@@ -1243,6 +1277,8 @@ namespace Cnp.Sdk
         }
         public partialCapture partialCapture; //12.38
         //12.31 end
+        //12.41 identityBundle
+        public identityBundle identityBundle;
 
         public override string Serialize()
         {
@@ -1272,7 +1308,7 @@ namespace Cnp.Sdk
                 xml += "\r\n<lodgingInfo>" + lodgingInfo.Serialize() + "\r\n</lodgingInfo>";
             }
             if (pin != null) xml += "\r\n<pin>" + pin + "</pin>";
-            if(passengerTransportData != null)//12.26
+            if (passengerTransportData != null)//12.26
             {
                 xml += "\r\n<passengerTransportData>" + passengerTransportData.Serialize() + "\r\n</passengerTransportData>";
             }
@@ -1283,6 +1319,10 @@ namespace Cnp.Sdk
             if (partialCapture != null)//12.38
             {
                 xml += "\r\n<partialCapture>" + partialCapture.Serialize() + "\r\n</partialCapture>";
+            }
+            if (identityBundle != null)  //12.41
+            {
+                xml += "\r\n<identityBundle>" + identityBundle.Serialize() + "</identityBundle>";
             }
             xml += "\r\n</capture>";
 
@@ -1327,8 +1367,8 @@ namespace Cnp.Sdk
             get { return taxTypeField; }
             set { taxTypeField = value; taxTypeSet = true; }
         }
-        
-        
+
+
         private businessIndicatorEnum businessIndicatorField;
         private bool businessIndicatorSet;
         public businessIndicatorEnum businessIndicator
@@ -1337,8 +1377,8 @@ namespace Cnp.Sdk
             set { businessIndicatorField = value; businessIndicatorSet = true; }
         }
 
-        
-        
+
+
         public billMeLaterRequest billMeLaterRequest;
         public enhancedData enhancedData;
         public lodgingInfo lodgingInfo;
@@ -1470,11 +1510,11 @@ namespace Cnp.Sdk
             if (orderSource != null) xml += "\r\n<orderSource>" + orderSource.Serialize() + "</orderSource>";
             if (billToAddress != null)
             {
-                xml += "\r\n<billToAddress>" + billToAddress.Serialize() + "\r\n</billToAddress>"; 
+                xml += "\r\n<billToAddress>" + billToAddress.Serialize() + "\r\n</billToAddress>";
             }
             if (retailerAddress != null)///12.24
             {
-                xml += "\r\n<retailerAddress>" + retailerAddress.Serialize() + "\r\n</retailerAddress>"; 
+                xml += "\r\n<retailerAddress>" + retailerAddress.Serialize() + "\r\n</retailerAddress>";
             }
             if (shipToAddress != null)
             {
@@ -1708,7 +1748,7 @@ namespace Cnp.Sdk
             get { return taxTypeField; }
             set { taxTypeField = value; taxTypeSet = true; }
         }
-        
+
         private businessIndicatorEnum businessIndicatorField;
         private bool businessIndicatorSet;
         public businessIndicatorEnum businessIndicator
@@ -1717,8 +1757,8 @@ namespace Cnp.Sdk
             set { businessIndicatorField = value; businessIndicatorSet = true; }
         }
 
-        
-        
+
+
         public billMeLaterRequest billMeLaterRequest;
         public pos pos;
         private string pinField;
@@ -1735,6 +1775,8 @@ namespace Cnp.Sdk
         public string payPalNotes;
         public string actionReason;
         public accountFundingTransactionData accountFundingTransactionData;
+        //12.41 identityBundle
+        public identityBundle identityBundle;
         public override string Serialize()
         {
             var xml = "\r\n<credit";
@@ -1816,6 +1858,10 @@ namespace Cnp.Sdk
             if (accountFundingTransactionData != null)
             {
                 xml += "\r\n<accountFundingTransactionData>" + accountFundingTransactionData.Serialize() + "\r\n</accountFundingTransactionData>";
+            }
+            if (identityBundle != null)  //12.41
+            {
+                xml += "\r\n<identityBundle>" + identityBundle.Serialize() + "</identityBundle>";
             }
             xml += "\r\n</credit>";
             return xml;
@@ -2010,7 +2056,7 @@ namespace Cnp.Sdk
                 xml += "\r\n<amount>" + amountField + "</amount>";
                 if (secondaryAmountSet) xml += "\r\n<secondaryAmount>" + secondaryAmountField + "</secondaryAmount>";
                 if (orderSource != null) xml += "\r\n<orderSource>" + orderSource.Serialize() + "</orderSource>";
-                if (billToAddress != null) xml += "\r\n<billToAddress>" + billToAddress.Serialize() + "</billToAddress>"; 
+                if (billToAddress != null) xml += "\r\n<billToAddress>" + billToAddress.Serialize() + "</billToAddress>";
                 if (retailerAddress != null) xml += "\r\n<retailerAddress>" + retailerAddress.Serialize() + "</retailerAddress>";///12.24
                 if (echeck != null) xml += "\r\n<echeck>" + echeck.Serialize() + "</echeck>";
                 else if (echeckToken != null) xml += "\r\n<echeckToken>" + echeckToken.Serialize() + "</echeckToken>";
@@ -2120,7 +2166,7 @@ namespace Cnp.Sdk
                 xml += "\r\n<amount>" + amountField + "</amount>";
                 if (secondaryAmountSet) xml += "\r\n<secondaryAmount>" + secondaryAmountField + "</secondaryAmount>";
                 if (orderSource != null) xml += "\r\n<orderSource>" + orderSource.Serialize() + "</orderSource>";
-                if (billToAddress != null) xml += "\r\n<billToAddress>" + billToAddress.Serialize() + "</billToAddress>"; 
+                if (billToAddress != null) xml += "\r\n<billToAddress>" + billToAddress.Serialize() + "</billToAddress>";
                 if (retailerAddress != null) xml += "\r\n<retailerAddress>" + retailerAddress.Serialize() + "</retailerAddress>";///12.24
                 if (shipToAddress != null) xml += "\r\n<shipToAddress>" + shipToAddress.Serialize() + "</shipToAddress>";
                 if (echeck != null) xml += "\r\n<echeck>" + echeck.Serialize() + "</echeck>";
@@ -2166,7 +2212,7 @@ namespace Cnp.Sdk
             xml += "\r\n<orderId>" + orderId + "</orderId>";
             if (amountSet) xml += "\r\n<amount>" + amountField + "</amount>";
             if (orderSource != null) xml += "\r\n<orderSource>" + orderSource.Serialize() + "</orderSource>";
-            if (billToAddress != null) xml += "\r\n<billToAddress>" + billToAddress.Serialize() + "</billToAddress>"; 
+            if (billToAddress != null) xml += "\r\n<billToAddress>" + billToAddress.Serialize() + "</billToAddress>";
             if (retailerAddress != null) xml += "\r\n<retailerAddress>" + retailerAddress.Serialize() + "</retailerAddress>";///12.24
             if (echeck != null) xml += "\r\n<echeck>" + echeck.Serialize() + "</echeck>";
             else if (token != null) xml += "\r\n<echeckToken>" + token.Serialize() + "</echeckToken>";
@@ -2195,10 +2241,10 @@ namespace Cnp.Sdk
             return xml;
         }
 
-        }
+    }
 
-        // Force Capture Transaction.
-        public partial class forceCapture : transactionTypeWithReportGroup
+    // Force Capture Transaction.
+    public partial class forceCapture : transactionTypeWithReportGroup
     {
         public string orderId;
         public long amount;
@@ -2231,7 +2277,7 @@ namespace Cnp.Sdk
             get { return taxTypeField; }
             set { taxTypeField = value; taxTypeSet = true; }
         }
-        
+
         private businessIndicatorEnum businessIndicatorField;
         private bool businessIndicatorSet;
         public businessIndicatorEnum businessIndicator
@@ -2239,10 +2285,10 @@ namespace Cnp.Sdk
             get { return businessIndicatorField; }
             set { businessIndicatorField = value; businessIndicatorSet = true; }
         }
-        
-        
-        
-        
+
+
+
+
         public enhancedData enhancedData;
         public lodgingInfo lodgingInfo;
         public processingInstructions processingInstructions;
@@ -2303,7 +2349,7 @@ namespace Cnp.Sdk
             if (orderSource != null) xml += "\r\n<orderSource>" + orderSource.Serialize() + "</orderSource>";
             if (billToAddress != null)
             {
-                xml += "\r\n<billToAddress>" + billToAddress.Serialize() + "\r\n</billToAddress>"; 
+                xml += "\r\n<billToAddress>" + billToAddress.Serialize() + "\r\n</billToAddress>";
             }
             if (retailerAddress != null)
             {
@@ -2832,7 +2878,7 @@ namespace Cnp.Sdk
             get { return taxTypeField; }
             set { taxTypeField = value; taxTypeSet = true; }
         }
-        
+
         private businessIndicatorEnum businessIndicatorField;
         private bool businessIndicatorSet;
         public businessIndicatorEnum businessIndicator
@@ -3146,6 +3192,8 @@ namespace Cnp.Sdk
             }
         }
 
+        //12.41 identityBundle
+        public identityBundle identityBundle;
 
         public override string Serialize()
         {
@@ -3172,11 +3220,11 @@ namespace Cnp.Sdk
             }
             if (billToAddress != null)
             {
-                xml += "\r\n<billToAddress>" + billToAddress.Serialize() + "\r\n</billToAddress>"; 
+                xml += "\r\n<billToAddress>" + billToAddress.Serialize() + "\r\n</billToAddress>";
             }
             if (retailerAddress != null)///12.24
             {
-                xml += "\r\n<retailerAddress>" + retailerAddress.Serialize() + "\r\n</retailerAddress>"; 
+                xml += "\r\n<retailerAddress>" + retailerAddress.Serialize() + "\r\n</retailerAddress>";
             }
             if (shipToAddress != null)
             {
@@ -3325,10 +3373,12 @@ namespace Cnp.Sdk
             {
                 xml += "\r\n<originalTransactionAmount>" + originalTransactionAmount + "</originalTransactionAmount>";
             }
-            if (pinlessDebitRequest != null) {
+            if (pinlessDebitRequest != null)
+            {
                 xml += "\r\n<pinlessDebitRequest>" + pinlessDebitRequest.Serialize() + "</pinlessDebitRequest>";
             }
-            if (skipRealtimeAU != null) {
+            if (skipRealtimeAU != null)
+            {
                 xml += "\r\n<skipRealtimeAU>" + skipRealtimeAU.ToString().ToLower() + "</skipRealtimeAU>";
             }
             if (merchantCategoryCode != null)
@@ -3389,17 +3439,21 @@ namespace Cnp.Sdk
             {
                 xml += "\r\n<conversionAffiliateId>" + conversionAffiliateIdField + "</conversionAffiliateId>";
             }
-        //end
-        //if (routingPreferenceSet)
-        //{
-        //    var routingPreferenceName = routingPreferenceField.ToString();
-        //    var attributes = 
-        //        (XmlEnumAttribute[])typeof(echeckAccountTypeEnum).GetMember(routingPreferenceField.ToString())[0].GetCustomAttributes(typeof(XmlEnumAttribute), false);
-        //    if (attributes.Length > 0) routingPreferenceName = attributes[0].Name;
-        //    xml += "\r\n<routingPreference>" + routingPreferenceName + "</routingPreference>";
-        //}
+            if (identityBundle != null) //12.41
+            {
+                xml += "\r\n<identityBundle>" + identityBundle.Serialize() + "</identityBundle>";
+            }
+            //end
+            //if (routingPreferenceSet)
+            //{
+            //    var routingPreferenceName = routingPreferenceField.ToString();
+            //    var attributes = 
+            //        (XmlEnumAttribute[])typeof(echeckAccountTypeEnum).GetMember(routingPreferenceField.ToString())[0].GetCustomAttributes(typeof(XmlEnumAttribute), false);
+            //    if (attributes.Length > 0) routingPreferenceName = attributes[0].Name;
+            //    xml += "\r\n<routingPreference>" + routingPreferenceName + "</routingPreference>";
+            //}
 
-        xml += "\r\n</sale>";
+            xml += "\r\n</sale>";
             return xml;
         }
     }
@@ -3691,7 +3745,7 @@ namespace Cnp.Sdk
             // The first element of a sequence xml element  represent the sequence element
             if (fundingSubmerchantId != null || fundingCustomerId != null)
             {
-                if (fundingSubmerchantId != null) 
+                if (fundingSubmerchantId != null)
                     xml += "\r\n<fundingSubmerchantId>" + fundingSubmerchantId + "</fundingSubmerchantId>";
                 else if (fundingCustomerId != null)
                     xml += "\r\n<fundingCustomerId>" + fundingCustomerId + "</fundingCustomerId>";
@@ -3827,13 +3881,13 @@ namespace Cnp.Sdk
         ///12.24
         public paymentTypeEnum paymentType
         {
-            get 
-            { 
+            get
+            {
                 return paymentTypeField;
             }
-            set 
-            { 
-                paymentTypeField = value; 
+            set
+            {
+                paymentTypeField = value;
                 paymentTypeSet = true;
             }
         }
@@ -3903,7 +3957,7 @@ namespace Cnp.Sdk
             var attributes =
                 (XmlEnumAttribute[])typeof(paymentTypeEnum).GetMember(paymentTypeField.ToString())[0].GetCustomAttributes(typeof(XmlEnumAttribute), false);
             if (attributes.Length > 0) accTypeName = attributes[0].Name;
-            
+
 
             if (paymentTypeSet) xml += "\r\n<paymentType>" + accTypeName + "</paymentType>";///12.24
 
@@ -4093,7 +4147,7 @@ namespace Cnp.Sdk
     //new 12.31 start
     public enum foreignRetailerIndicatorEnum
     {
-       F
+        F
     }
     // 12.31 end
     #endregion
@@ -4135,7 +4189,7 @@ namespace Cnp.Sdk
     {
         APPROVED_SKIP_FRAUD_CHECK,
         DECLINED_NEED_FRAUD_CHECK,
-    } 
+    }
     public enum provider
     {
         AFFIRM
@@ -4197,11 +4251,11 @@ namespace Cnp.Sdk
         ///new 12.24 start
         public string accountUsername;
         public string userAccountNumber;
-        
+
         public string membershipId;
         public string membershipName;
         public string membershipPhone;
-        public string membershipEmail;    
+        public string membershipEmail;
         public DateTime accountCreatedDate;
         public string userAccountPhone;
         public string userAccountEmail;
@@ -4283,7 +4337,7 @@ namespace Cnp.Sdk
             if (employerName != null)
             {
                 xml += "\r\n<employerName>" + SecurityElement.Escape(employerName) + "</employerName>";
-            }            
+            }
             if (customerWorkTelephone != null)
             {
                 xml += "\r\n<customerWorkTelephone>" + SecurityElement.Escape(customerWorkTelephone) + "</customerWorkTelephone>";
@@ -4324,7 +4378,7 @@ namespace Cnp.Sdk
             if (membershipEmail != null)
             {
                 xml += "\r\n<membershipEmail>" + SecurityElement.Escape(membershipEmail) + "</membershipEmail>";
-            } 
+            }
             if (membershipName != null)
             {
                 xml += "\r\n<membershipName>" + SecurityElement.Escape(membershipName) + "</membershipName>";
@@ -4332,7 +4386,7 @@ namespace Cnp.Sdk
             if (accountCreatedDate != null)
             {
                 xml += "\r\n<accountCreatedDate>" + XmlUtil.toXsdDate(accountCreatedDate) + "</accountCreatedDate>";
-            } 
+            }
             if (userAccountPhone != null)
             {
                 xml += "\r\n<userAccountPhone>" + SecurityElement.Escape(userAccountPhone) + "</userAccountPhone>";
@@ -4451,9 +4505,9 @@ namespace Cnp.Sdk
         private bool fulfilmentMethodTypeSet;
         public fulfilmentMethodTypeEnum fulfilmentMethodType
         {
-            get 
+            get
             {
-                return fulfilmentMethodTypeField; 
+                return fulfilmentMethodTypeField;
             }
             set
             {
@@ -4571,7 +4625,7 @@ namespace Cnp.Sdk
             detailTaxes = new List<detailTax>();
             subscription = new List<subscriptions>();
         }
-        
+
         public string Serialize()
         {
             var xml = "";
@@ -4732,7 +4786,7 @@ namespace Cnp.Sdk
             if (accountId != null) xml += "\r\n<accountId>" + SecurityElement.Escape(accountId) + "</accountId>";
             return xml;
         }
-        
+
     }
 
     public partial class echeckTokenType
@@ -4853,7 +4907,7 @@ namespace Cnp.Sdk
         public string tokenUrl;
         public string expDate;
         public string cardValidationNum;
-	    private string authenticatedShopperID;
+        private string authenticatedShopperID;
         private methodOfPaymentTypeEnum typeField;
         private bool typeSet;
         public methodOfPaymentTypeEnum type
@@ -4868,12 +4922,14 @@ namespace Cnp.Sdk
         public string checkoutId
         {
             get { return checkoutIdField; }
-            set { checkoutIdField = value;
+            set
+            {
+                checkoutIdField = value;
                 checkoutIdSet = true;
             }
         }
 
- 
+
 
         public string Serialize()
         {
@@ -4884,7 +4940,7 @@ namespace Cnp.Sdk
             if (cardValidationNum != null) xml += "\r\n<cardValidationNum>" + SecurityElement.Escape(cardValidationNum) + "</cardValidationNum>";
             if (typeSet) xml += "\r\n<type>" + methodOfPaymentSerializer.Serialize(typeField) + "</type>";
             if (checkoutIdSet) xml += "\r\n<checkoutId>" + checkoutId + "</checkoutId>";
-	    if (authenticatedShopperID != null) xml += "\r\n<authenticatednShopperID>" + authenticatedShopperID + "</authenticatedShopperID>";
+            if (authenticatedShopperID != null) xml += "\r\n<authenticatednShopperID>" + authenticatedShopperID + "</authenticatedShopperID>";
             return xml;
         }
     }
@@ -5543,8 +5599,8 @@ namespace Cnp.Sdk
         private bool sequenceIndicatorSet;
         public int sequenceIndicator
         {
-            get 
-            { 
+            get
+            {
                 return sequenceIndicatorField;
             }
             set
@@ -5583,13 +5639,13 @@ namespace Cnp.Sdk
         private bool bookingIDSet;
         public string bookingID
         {
-            get 
-            { 
-                return bookingIDField; 
+            get
+            {
+                return bookingIDField;
             }
-            set 
-            { 
-                bookingIDField = value; 
+            set
+            {
+                bookingIDField = value;
                 bookingIDSet = true;
             }
         }
@@ -5597,13 +5653,13 @@ namespace Cnp.Sdk
         private bool passengerNameSet;
         public string passengerName
         {
-            get 
-            { 
-                return passengerNameField; 
+            get
+            {
+                return passengerNameField;
             }
-            set 
-            { 
-                passengerNameField = value; 
+            set
+            {
+                passengerNameField = value;
                 passengerNameSet = true;
             }
         }
@@ -5612,9 +5668,9 @@ namespace Cnp.Sdk
         private bool travelPackageIndicatorSet;
         public travelPackageIndicatorEnum travelPackageIndicator
         {
-            get 
+            get
             {
-                return travelPackageIndicatorField; 
+                return travelPackageIndicatorField;
             }
             set
             {
@@ -5648,9 +5704,9 @@ namespace Cnp.Sdk
         private bool tollFreePhoneNumberSet;
         public string tollFreePhoneNumber
         {
-            get 
-            { 
-                return tollFreePhoneNumberField; 
+            get
+            {
+                return tollFreePhoneNumberField;
             }
             set
             {
@@ -5660,14 +5716,14 @@ namespace Cnp.Sdk
         }
         //12.25 end
 
-        
 
-       /* public lodgingInfo()
-        {
 
-            lodgingCharges = new List<lodgingCharge>();
+        /* public lodgingInfo()
+         {
 
-        }*/
+             lodgingCharges = new List<lodgingCharge>();
+
+         }*/
 
         public string Serialize()
         {
@@ -5798,14 +5854,14 @@ namespace Cnp.Sdk
         }
 
 
-	private int copayAmountField;
-	private bool copayAmountSet;
-	public int copayAmount
-	{
-		get { return copayAmountField; }
-		set { copayAmountField = value; copayAmountSet = true; }
-	}
-	
+        private int copayAmountField;
+        private bool copayAmountSet;
+        public int copayAmount
+        {
+            get { return copayAmountField; }
+            set { copayAmountField = value; copayAmountSet = true; }
+        }
+
         public string Serialize()
         {
             var xml = "";
@@ -5814,7 +5870,7 @@ namespace Cnp.Sdk
             if (visionAmountSet) xml += "\r\n<visionAmount>" + visionAmountField + "</visionAmount>";
             if (clinicOtherAmountSet) xml += "\r\n<clinicOtherAmount>" + clinicOtherAmountField + "</clinicOtherAmount>";
             if (dentalAmountSet) xml += "\r\n<dentalAmount>" + dentalAmountField + "</dentalAmount>";
-	    if (copayAmountSet) xml += "\r\n<copayAmount>" + copayAmountField + "</copayAmount>";
+            if (copayAmountSet) xml += "\r\n<copayAmount>" + copayAmountField + "</copayAmount>";
             return xml;
         }
     }
@@ -5833,10 +5889,15 @@ namespace Cnp.Sdk
         public static readonly orderSourceType echeckppd = new orderSourceType("echeckppd");
         public static readonly orderSourceType applepay = new orderSourceType("applepay");
         public static readonly orderSourceType androidpay = new orderSourceType("androidpay");
-
+        public static readonly orderSourceType ecommerceDataOnly = new orderSourceType("ecommerceDataOnly");  //12.44
         private orderSourceType(string value) { this.value = value; }
         public string Serialize() { return value; }
         private string value;
+
+        //adding non parameterized constructor to make deserialize work  for ordersource-added in authorizationResponse and saleResponse. 12.41
+        public orderSourceType()
+        {
+        }
     }
 
     public partial class contact
@@ -6216,7 +6277,7 @@ namespace Cnp.Sdk
     }
 
     public partial class addressType
-    {        
+    {
         public string addressLine1;
         public string addressLine2;
         public string addressLine3;
@@ -6229,18 +6290,18 @@ namespace Cnp.Sdk
         {
             get { return countryField; }
             set { countryField = value; countrySpecified = true; }
-        }        
+        }
 
         public string Serialize()
         {
-            var xml = "";            
+            var xml = "";
             if (addressLine1 != null) xml += "\r\n<addressLine1>" + SecurityElement.Escape(addressLine1) + "</addressLine1>";
             if (addressLine2 != null) xml += "\r\n<addressLine2>" + SecurityElement.Escape(addressLine2) + "</addressLine2>";
             if (addressLine3 != null) xml += "\r\n<addressLine3>" + SecurityElement.Escape(addressLine3) + "</addressLine3>";
             if (city != null) xml += "\r\n<city>" + SecurityElement.Escape(city) + "</city>";
             if (state != null) xml += "\r\n<state>" + SecurityElement.Escape(state) + "</state>";
             if (zip != null) xml += "\r\n<zip>" + SecurityElement.Escape(zip) + "</zip>";
-            if (countrySpecified) xml += "\r\n<country>" + countryField + "</country>";            
+            if (countrySpecified) xml += "\r\n<country>" + countryField + "</country>";
             return xml;
         }
     }
@@ -6485,7 +6546,7 @@ namespace Cnp.Sdk
         public string lastName;
         public string phoneNumber;
         public string email;
-    
+
         public override string Serialize()
         {
             var xml = "\r\n<finicityUrlRequest";
@@ -6508,7 +6569,7 @@ namespace Cnp.Sdk
     public partial class finicityAccountRequest : transactionTypeWithReportGroup
     {
         public string echeckCustomerId;
-      
+
         public override string Serialize()
         {
             var xml = "\r\n<finicityAccountRequest";
@@ -6896,7 +6957,7 @@ namespace Cnp.Sdk
     //12.38
     public partial class partialCapture
     {
-       
+
         private int partialCaptureSequenceNumberField;
         private bool partialCaptureSequenceNumberSet;
         public int partialCaptureSequenceNumber
@@ -6916,7 +6977,7 @@ namespace Cnp.Sdk
         {
             var xml = "";
             if (partialCaptureSequenceNumberSet) xml += "\r\n<partialCaptureSequenceNumber>" + partialCaptureSequenceNumberField + "</partialCaptureSequenceNumber>";
-            if (partialCaptureTotalCountSet) xml += "\r\n<partialCaptureTotalCount>" + partialCaptureTotalCountField + "</partialCaptureTotalCount>"; 
+            if (partialCaptureTotalCountSet) xml += "\r\n<partialCaptureTotalCount>" + partialCaptureTotalCountField + "</partialCaptureTotalCount>";
             return xml;
         }
     }
@@ -7186,7 +7247,7 @@ namespace Cnp.Sdk
             }
             xml += " reportGroup=\"" + SecurityElement.Escape(reportGroup) + "\">";
             if (advancedFraudChecks != null) xml += "\r\n<advancedFraudChecks>" + advancedFraudChecks.Serialize() + "\r\n</advancedFraudChecks>";
-            if (billToAddressSet) xml += "\r\n<billToAddress>" + billToAddressField.Serialize() + "</billToAddress>"; 
+            if (billToAddressSet) xml += "\r\n<billToAddress>" + billToAddressField.Serialize() + "</billToAddress>";
             if (retailerAddressSet) xml += "\r\n<retailerAddress>" + retailerAddressField.Serialize() + "</retailerAddress>";///12.24
             if (shipToAddressSet) xml += "\r\n<shipToAddress>" + shipToAddressField.Serialize() + "</shipToAddress>";
             if (amountSet) xml += "\r\n<amount>" + amountField.ToString() + "</amount>";
@@ -7434,7 +7495,7 @@ namespace Cnp.Sdk
 
         public countryTypeEnum receiverCountryFeild;
         public bool receiverCountrySet;
-       
+
         public countryTypeEnum receiverCountry
         {
             get
@@ -7494,7 +7555,7 @@ namespace Cnp.Sdk
             {
                 xml += "\r\n<receiverCountry>" + receiverCountry + "</receiverCountry>";
             }
-            if(receiverAccountNumberTypeSet)
+            if (receiverAccountNumberTypeSet)
             {
                 xml += "\r\n<receiverAccountNumberType>" + receiverAccountNumberType + "</receiverAccountNumberType>";
             }
@@ -7533,7 +7594,7 @@ namespace Cnp.Sdk
                 xml += " customerId=\"" + SecurityElement.Escape(customerId) + "\"";
             }
             xml += " reportGroup=\"" + SecurityElement.Escape(reportGroup) + "\">";
-           
+
             xml += "\r\n<amount>" + amount + "</amount>";
             xml += "\r\n<orderId>" + SecurityElement.Escape(orderId) + "</orderId>";
             if (providerSet)
@@ -7541,13 +7602,13 @@ namespace Cnp.Sdk
                 xml += "\r\n<provider>" + provider + "</provider>";
             }
             if (postCheckoutRedirectUrl != null)
-                {
+            {
                 xml += "\r\n<postCheckoutRedirectUrl>" + postCheckoutRedirectUrl + "</postCheckoutRedirectUrl>";
             }
             if (customerInfo != null)
             {
                 xml += "\r\n<customerInfo>" + customerInfo.Serialize() + "\r\n</customerInfo>";
-            }   
+            }
             if (billToAddress != null)
             {
                 xml += "\r\n<billToAddress>" + billToAddress.Serialize() + "\r\n</billToAddress>";
@@ -7555,7 +7616,7 @@ namespace Cnp.Sdk
             if (shipToAddress != null)
             {
                 xml += "\r\n<shipToAddress>" + shipToAddress.Serialize() + "\r\n</shipToAddress>";
-            }              
+            }
             if (enhancedData != null)
             {
                 xml += "\r\n<enhancedData>" + enhancedData.Serialize() + "\r\n</enhancedData>";
@@ -7709,7 +7770,7 @@ namespace Cnp.Sdk
                 xml += " customerId=\"" + SecurityElement.Escape(customerId) + "\"";
             }
             xml += " reportGroup=\"" + SecurityElement.Escape(reportGroup) + "\">";
-       
+
             xml += "\r\n<orderId>" + SecurityElement.Escape(orderId) + "</orderId>";
             if (cnpTxnIdSet)
             {
@@ -7739,11 +7800,214 @@ namespace Cnp.Sdk
         public override string Serialize()
         {
             var xml = " ";
-       
+
             if (encryptionKeyRequestSet)
             {
                 xml += "\r<encryptionKeyRequest>" + encryptionKeyRequest + "</encryptionKeyRequest>";
             }
+            return xml;
+        }
+    }
+
+    //12.42 New txn type 
+    public partial class realtimeIncrementalAuthorization : transactionTypeWithReportGroup
+    {
+        private long cnpTxnIdField;
+        private bool cnpTxnIdSet;
+        public long cnpTxnId
+        {
+            get
+            {
+                return cnpTxnIdField;
+            }
+            set
+            {
+                cnpTxnIdField = value;
+                cnpTxnIdSet = true;
+            }
+        }
+        public string orderId;
+        public long amount;
+        public orderSourceType orderSource;
+        public contact billToAddress;
+        public contact shipToAddress;
+        public cardType card;
+        public cardTokenType token;
+        public applepayType applepay;
+        public cardPaypageType paypage;
+        public fraudCheckType cardholderAuthentication;
+        public customBilling customBilling;
+        private bool allowPartialAuthField;
+        private bool allowPartialAuthSet;
+        public bool allowPartialAuth
+        {
+            get
+            {
+                return allowPartialAuthField;
+            }
+            set
+            {
+                allowPartialAuthField = value;
+                allowPartialAuthSet = true;
+            }
+        }
+
+        public wallet wallet;
+        private string originalNetworkTransactionIdField;
+        private bool originalNetworkTransactionIdSet;
+        public string originalNetworkTransactionId
+        {
+            get
+            {
+                return originalNetworkTransactionIdField;
+            }
+            set
+            {
+                originalNetworkTransactionIdField = value;
+                originalNetworkTransactionIdSet = true;
+            }
+        }
+        public string merchantCategoryCode;
+        public string originalRetrievalReferenceNumber;
+        public long cumulativeAmountField;
+        public bool cumulativeAmountSet;
+        public long cumulativeAmount
+        {
+            get
+            {
+                return cumulativeAmountField;
+            }
+            set
+            {
+                cumulativeAmountField = value;
+                cumulativeAmountSet = true;
+            }
+        }
+
+        private long originalTransactionAmountField;
+        private bool originalTransactionAmountSet;
+        public long originalTransactionAmount
+        {
+            get
+            {
+                return originalTransactionAmountField;
+            }
+            set
+            {
+                originalTransactionAmountField = value;
+                originalTransactionAmountSet = true;
+            }
+        }
+        public override string Serialize()
+        {
+            var xml = "\r\n<realtimeIncrementalAuthorization";
+
+            xml += " id=\"" + SecurityElement.Escape(id) + "\"";
+            if (customerId != null)
+            {
+                xml += " customerId=\"" + SecurityElement.Escape(customerId) + "\"";
+            }
+            xml += " reportGroup=\"" + SecurityElement.Escape(reportGroup) + "\">";
+            if (cnpTxnIdSet)
+            {
+                xml += "\r\n<cnpTxnId>" + cnpTxnIdField + "</cnpTxnId>";
+            }
+            xml += "\r\n<orderId>" + SecurityElement.Escape(orderId) + "</orderId>";
+            xml += "\r\n<amount>" + amount + "</amount>";
+
+            if (orderSource != null)
+            {
+                xml += "\r<orderSource>" + orderSource.Serialize() + "</orderSource>";
+            }
+            if (billToAddress != null)
+            {
+                xml += "\r\n<billToAddress>" + billToAddress.Serialize() + "\r\n</billToAddress>";
+            }
+            if (shipToAddress != null)
+            {
+                xml += "\r<shipToAddress>" + shipToAddress.Serialize() + "</shipToAddress>";
+            }
+            if (card != null)
+            {
+                xml += "\r\n<card>" + card.Serialize() + "\r\n</card>";
+            }
+            else if (token != null)
+            {
+                xml += "\r<token>" + token.Serialize() + "</token>";
+            }
+            else if (paypage != null)
+            {
+                xml += "\r<paypage>" + paypage.Serialize() + "</paypage>";
+            }
+            else if (applepay != null)
+            {
+                xml += "\r<applepay>" + applepay.Serialize() + "</applepay>";
+            }
+            if (cardholderAuthentication != null)
+            {
+                xml += "\r<cardholderAuthentication>" + cardholderAuthentication.Serialize() + "</cardholderAuthentication>";
+            }
+            if (customBilling != null)
+            {
+                xml += "\r<customBilling>" + customBilling.Serialize() + "</customBilling>";
+            }
+            if (allowPartialAuthSet)
+            {
+                xml += "\r\n<allowPartialAuth>" + allowPartialAuthField.ToString().ToLower() + "</allowPartialAuth>";
+            }
+            if (wallet != null)
+            {
+                xml += "\r\n<wallet>" + wallet.Serialize() + "\r\n</wallet>";
+            }
+            if (originalNetworkTransactionIdSet)
+            {
+                xml += "\r\n<originalNetworkTransactionId>" + originalNetworkTransactionId + "</originalNetworkTransactionId>";
+            }
+            if (!string.IsNullOrEmpty(merchantCategoryCode))
+            {
+                xml += "\r<merchantCategoryCode>" + merchantCategoryCode + "</merchantCategoryCode>";
+            }
+            if (!string.IsNullOrEmpty(originalRetrievalReferenceNumber))
+            {
+                xml += "\r\n<originalRetrievalReferenceNumber>" + originalRetrievalReferenceNumber + "</originalRetrievalReferenceNumber>";
+            }
+            if (cumulativeAmountSet)
+            {
+                xml += "\r\n<cumulativeAmount>" + cumulativeAmount + "</cumulativeAmount>";
+            }
+            if (originalTransactionAmountSet)
+            {
+                xml += "\r\n<originalTransactionAmount>" + originalTransactionAmount + "</originalTransactionAmount>";
+            }
+            xml += "\r\n</realtimeIncrementalAuthorization>";
+            return xml;
+        }
+    }
+
+    //v12.41
+    public partial class identityBundle
+    {
+        public string merchantId;
+        public string entityId;
+        public string entityReference;
+        public string resourceId;
+        public string resourceReference;
+        public string commandId;
+        public string commandReference;
+        public string orderReference;
+
+        public string Serialize()
+        {
+            var xml = "";
+            xml += "\r\n<merchantId>" + merchantId + "</merchantId>";
+            xml += "\r\n<entityId>" + entityId + "</entityId>";
+            xml += "\r\n<entityReference>" + entityReference + "</entityReference>";
+            xml += "\r\n<resourceId>" + resourceId + "</resourceId>";
+            xml += "\r\n<resourceReference>" + resourceReference + "</resourceReference>";
+            xml += "\r\n<commandId>" + commandId + "</commandId>";
+            xml += "\r\n<commandReference>" + commandReference + "</commandReference>";
+            xml += "\r\n<orderReference>" + orderReference + "</orderReference>";
+
             return xml;
         }
     }

--- a/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
+++ b/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
@@ -75,7 +75,6 @@ namespace Cnp.Sdk
         public updateSubscription updateSubscription;
         public voidTxn voidTxn;
         public translateToLowValueTokenRequest translateToLowValueTokenRequest;
-        public realtimeIncrementalAuthorization realtimeIncrementalAuthorization;
 
         // Serialize the cnpOnlineRequest.
         // Convert the cnpOnlineRequest object to xml string.
@@ -149,7 +148,6 @@ namespace Cnp.Sdk
             else if (BNPLCancelRequest != null) xml += BNPLCancelRequest.Serialize();
             else if (BNPLInquiryRequest != null) xml += BNPLInquiryRequest.Serialize();
             else if (encryptionKeyRequest != null) xml += encryptionKeyRequest.Serialize();
-            else if (realtimeIncrementalAuthorization != null) xml += realtimeIncrementalAuthorization.Serialize();
             xml += "\r\n</cnpOnlineRequest>";
 
             return xml;
@@ -620,9 +618,6 @@ namespace Cnp.Sdk
             }
         }
 
-        public identityBundle identityBundle;  //12.41
-        public string originalRetrievalReferenceNumber;  //12.42
-
         public override string Serialize()
         {
             var xml = "\r\n<authorization";
@@ -861,14 +856,6 @@ namespace Cnp.Sdk
                 {
                     xml += "\r\n<conversionAffiliateId>" + conversionAffiliateIdField + "</conversionAffiliateId>";
                 }
-                if (identityBundle != null) //12.41
-                {
-                    xml += "\r\n<identityBundle>" + identityBundle.Serialize() + "\r\n</identityBundle>"; 
-                }
-                if (originalRetrievalReferenceNumber != null) //12.42
-                {
-                    xml += "\r\n<originalRetrievalReferenceNumber>" + originalRetrievalReferenceNumber + "</originalRetrievalReferenceNumber>"; 
-                }
             }
 
             xml += "\r\n</authorization>";
@@ -897,8 +884,6 @@ namespace Cnp.Sdk
         public string payPalNotes;
         public string actionReason;
         public additionalCOFData additionalCOFData;//12.26
-        //12.41 identityBundle
-        public identityBundle identityBundle;
 
         public override string Serialize()
         {
@@ -926,10 +911,6 @@ namespace Cnp.Sdk
             if (additionalCOFData != null)///12.26
             {
                 xml += "\r\n<additionalCOFData>" + additionalCOFData.Serialize() + "\r\n</additionalCOFData>";
-            }
-            if (identityBundle != null)  //12.41
-            {
-                xml += "\r\n<identityBundle>" + identityBundle.Serialize() + "</identityBundle>";
             }
             xml += "\r\n</authReversal>";
             return xml;
@@ -998,8 +979,6 @@ namespace Cnp.Sdk
         }
 
         public passengerTransportData passengerTransportData;//12.26
-        //12.41 identityBundle
-        public identityBundle identityBundle;
 
         public override string Serialize()
         {
@@ -1048,10 +1027,6 @@ namespace Cnp.Sdk
             if (passengerTransportData != null)//12.26
             {
                 xml += "\r\n<passengerTransportData>" + passengerTransportData.Serialize() + "</passengerTransportData>";
-            }
-            if (identityBundle != null)  //12.41
-            {
-                xml += "\r\n<identityBundle>" + identityBundle.Serialize() + "</identityBundle>";
             }
             xml += "\r\n</depositTransactionReversal>";
             return xml;
@@ -1119,8 +1094,6 @@ namespace Cnp.Sdk
         }
 
         public passengerTransportData passengerTransportData;//12.26
-        //12.41 identityBundle
-        public identityBundle identityBundle;
 
         public override string Serialize()
         {
@@ -1169,10 +1142,6 @@ namespace Cnp.Sdk
             if (passengerTransportData != null)//12.26
             {
                 xml += "\r\n<passengerTransportData>" + passengerTransportData.Serialize() + "</passengerTransportData>";
-            }
-            if (identityBundle != null)  //12.41
-            {
-                xml += "\r\n<identityBundle>" + identityBundle.Serialize() + "</identityBundle>";
             }
             xml += "\r\n</refundTransactionReversal>";
             return xml;
@@ -1274,8 +1243,6 @@ namespace Cnp.Sdk
         }
         public partialCapture partialCapture; //12.38
         //12.31 end
-        //12.41 identityBundle
-        public identityBundle identityBundle;
 
         public override string Serialize()
         {
@@ -1316,10 +1283,6 @@ namespace Cnp.Sdk
             if (partialCapture != null)//12.38
             {
                 xml += "\r\n<partialCapture>" + partialCapture.Serialize() + "\r\n</partialCapture>";
-            }
-            if (identityBundle != null)  //12.41
-            {
-                xml += "\r\n<identityBundle>" + identityBundle.Serialize() + "</identityBundle>";
             }
             xml += "\r\n</capture>";
 
@@ -1772,8 +1735,6 @@ namespace Cnp.Sdk
         public string payPalNotes;
         public string actionReason;
         public accountFundingTransactionData accountFundingTransactionData;
-        //12.41 identityBundle
-        public identityBundle identityBundle;
         public override string Serialize()
         {
             var xml = "\r\n<credit";
@@ -1855,10 +1816,6 @@ namespace Cnp.Sdk
             if (accountFundingTransactionData != null)
             {
                 xml += "\r\n<accountFundingTransactionData>" + accountFundingTransactionData.Serialize() + "\r\n</accountFundingTransactionData>";
-            }
-            if (identityBundle != null)  //12.41
-            {
-                xml += "\r\n<identityBundle>" + identityBundle.Serialize() + "</identityBundle>";
             }
             xml += "\r\n</credit>";
             return xml;
@@ -3189,8 +3146,6 @@ namespace Cnp.Sdk
             }
         }
 
-        //12.41 identityBundle
-        public identityBundle identityBundle;
 
         public override string Serialize()
         {
@@ -3434,21 +3389,17 @@ namespace Cnp.Sdk
             {
                 xml += "\r\n<conversionAffiliateId>" + conversionAffiliateIdField + "</conversionAffiliateId>";
             }
-            if (identityBundle != null) //12.41
-            {
-                xml += "\r\n<identityBundle>" + identityBundle.Serialize() + "</identityBundle>";
-            }
-            //end
-            //if (routingPreferenceSet)
-            //{
-            //    var routingPreferenceName = routingPreferenceField.ToString();
-            //    var attributes = 
-            //        (XmlEnumAttribute[])typeof(echeckAccountTypeEnum).GetMember(routingPreferenceField.ToString())[0].GetCustomAttributes(typeof(XmlEnumAttribute), false);
-            //    if (attributes.Length > 0) routingPreferenceName = attributes[0].Name;
-            //    xml += "\r\n<routingPreference>" + routingPreferenceName + "</routingPreference>";
-            //}
+        //end
+        //if (routingPreferenceSet)
+        //{
+        //    var routingPreferenceName = routingPreferenceField.ToString();
+        //    var attributes = 
+        //        (XmlEnumAttribute[])typeof(echeckAccountTypeEnum).GetMember(routingPreferenceField.ToString())[0].GetCustomAttributes(typeof(XmlEnumAttribute), false);
+        //    if (attributes.Length > 0) routingPreferenceName = attributes[0].Name;
+        //    xml += "\r\n<routingPreference>" + routingPreferenceName + "</routingPreference>";
+        //}
 
-            xml += "\r\n</sale>";
+        xml += "\r\n</sale>";
             return xml;
         }
     }
@@ -5881,16 +5832,11 @@ namespace Cnp.Sdk
         public static readonly orderSourceType recurringtel = new orderSourceType("recurringtel");
         public static readonly orderSourceType echeckppd = new orderSourceType("echeckppd");
         public static readonly orderSourceType applepay = new orderSourceType("applepay");
-        public static readonly orderSourceType androidpay = new orderSourceType("androidpay"); 
-        public static readonly orderSourceType ecommerceDataOnly = new orderSourceType("ecommerceDataOnly");  //12.44
+        public static readonly orderSourceType androidpay = new orderSourceType("androidpay");
+
         private orderSourceType(string value) { this.value = value; }
         public string Serialize() { return value; }
         private string value;
-
-        //adding non parameterized constructor to make deserialize work  for ordersource-added in authorizationResponse and saleResponse.
-        public orderSourceType()
-        {
-        }
     }
 
     public partial class contact
@@ -7802,211 +7748,6 @@ namespace Cnp.Sdk
         }
     }
 
-    public partial class realtimeIncrementalAuthorization : transactionTypeWithReportGroup
-    {
-        private long cnpTxnIdField;
-        private bool cnpTxnIdSet;
-        public long cnpTxnId
-        {
-            get
-            {
-                return cnpTxnIdField;
-            }
-            set
-            {
-                cnpTxnIdField = value;
-                cnpTxnIdSet = true;
-            }
-        }
-        public string orderId;
-        public long amount;
-        public orderSourceType orderSource;
-        public contact billToAddress;
-        public contact shipToAddress;
-        public cardType card;
-        public cardTokenType token;
-        public applepayType applepay;
-        public cardPaypageType paypage;
-        public fraudCheckType cardholderAuthentication;
-        public customBilling customBilling;
-        private bool allowPartialAuthField;
-        private bool allowPartialAuthSet;
-        public bool allowPartialAuth
-        {
-            get
-            {
-                return allowPartialAuthField;
-            }
-            set
-            {
-                allowPartialAuthField = value;
-                allowPartialAuthSet = true;
-            }
-        }
-
-        public wallet wallet;
-        private string originalNetworkTransactionIdField;
-        private bool originalNetworkTransactionIdSet;
-        public string originalNetworkTransactionId
-        {
-            get
-            {
-                return originalNetworkTransactionIdField;
-            }
-            set
-            {
-                originalNetworkTransactionIdField = value;
-                originalNetworkTransactionIdSet = true;
-            }
-        }
-        public string merchantCategoryCode;
-        public string originalRetrievalReferenceNumber;
-        public long cumulativeAmountField;
-        public bool cumulativeAmountSet;
-        public long cumulativeAmount
-        {
-            get
-            {
-                return cumulativeAmountField;
-            }
-            set
-            {
-                cumulativeAmountField = value;
-                cumulativeAmountSet = true;
-            }
-        }
-
-        private long originalTransactionAmountField;
-        private bool originalTransactionAmountSet;
-        public long originalTransactionAmount
-        {
-            get
-            {
-                return originalTransactionAmountField;
-            }
-            set
-            {
-                originalTransactionAmountField = value;
-                originalTransactionAmountSet = true;
-            }
-        }
-
-        public override string Serialize()
-        {
-            var xml = "\r\n<realtimeIncrementalAuthorization";
-
-            xml += " id=\"" + SecurityElement.Escape(id) + "\"";
-            if (customerId != null)
-            {
-                xml += " customerId=\"" + SecurityElement.Escape(customerId) + "\"";
-            }
-            xml += " reportGroup=\"" + SecurityElement.Escape(reportGroup) + "\">";
-            if (cnpTxnIdSet)
-            {
-                xml += "\r\n<cnpTxnId>" + cnpTxnIdField + "</cnpTxnId>";
-            }
-            xml += "\r\n<orderId>" + SecurityElement.Escape(orderId) + "</orderId>";
-            xml += "\r\n<amount>" + amount + "</amount>";
-              
-            if (orderSource != null)
-            {
-                xml += "\r<orderSource>" + orderSource.Serialize() + "</orderSource>";
-            }
-            if (billToAddress != null)
-            {
-                xml += "\r\n<billToAddress>" + billToAddress.Serialize() + "\r\n</billToAddress>";
-            }
-            if (shipToAddress != null)
-            {
-                xml += "\r<shipToAddress>" + shipToAddress.Serialize() + "</shipToAddress>";
-            }
-            if (card != null)
-            {
-                xml += "\r\n<card>" + card.Serialize() + "\r\n</card>";
-            }
-            else if (token != null)
-            {
-                xml += "\r<token>" + token.Serialize() + "</token>";
-            }
-            else if (paypage != null)
-            {
-                xml += "\r<paypage>" + paypage.Serialize() + "</paypage>";
-            }
-            else if (applepay != null)
-            {
-                xml += "\r<applepay>" + applepay.Serialize() + "</applepay>";
-            }
-            if (cardholderAuthentication != null)
-            {
-                xml += "\r<cardholderAuthentication>" + cardholderAuthentication.Serialize() + "</cardholderAuthentication>";
-            }
-            if (customBilling != null)
-            {
-                xml += "\r<customBilling>" + customBilling.Serialize() + "</customBilling>";
-            }
-            if (allowPartialAuthSet)
-            {
-                xml += "\r\n<allowPartialAuth>" + allowPartialAuthField.ToString().ToLower() + "</allowPartialAuth>";
-            }
-            if (wallet != null)
-            {
-                xml += "\r\n<wallet>" + wallet.Serialize() + "\r\n</wallet>";
-            }
-            if (originalNetworkTransactionIdSet)
-            {
-                xml += "\r\n<originalNetworkTransactionId>" + originalNetworkTransactionId + "</originalNetworkTransactionId>";
-            }
-            if (!string.IsNullOrEmpty(merchantCategoryCode))
-            {
-                xml += "\r<merchantCategoryCode>" + merchantCategoryCode + "</merchantCategoryCode>";
-            }
-            if (!string.IsNullOrEmpty(originalRetrievalReferenceNumber))
-            {
-                xml += "\r\n<originalRetrievalReferenceNumber>" +originalRetrievalReferenceNumber + "</originalRetrievalReferenceNumber>";
-            }
-            if (cumulativeAmountSet)
-            {
-                xml += "\r\n<cumulativeAmount>" + cumulativeAmount + "</cumulativeAmount>";
-            }
-             if (originalTransactionAmountSet)
-            { 
-            xml += "\r\n<originalTransactionAmount>" + originalTransactionAmount + "</originalTransactionAmount>";
-            }
-            xml += "\r\n</realtimeIncrementalAuthorization>";
-            return xml;
-        }
-    }
-
-
-    //v12.41
-
-    public partial class identityBundle
-    {
-        public string merchantId;
-        public string entityId;
-        public string entityReference;
-        public string resourceId;
-        public string resourceReference;
-        public string commandId;
-        public string commandReference;
-        public string orderReference;
-
-        public string Serialize()
-        {
-            var xml = "";
-            xml += "\r\n<merchantId>" + merchantId + "</merchantId>";
-            xml += "\r\n<entityId>" + entityId + "</entityId>";
-            xml += "\r\n<entityReference>" + entityReference + "</entityReference>";
-            xml += "\r\n<resourceId>" + resourceId + "</resourceId>";
-            xml += "\r\n<resourceReference>" + resourceReference + "</resourceReference>";
-            xml += "\r\n<commandId>" + commandId + "</commandId>";
-            xml += "\r\n<commandReference>" + commandReference + "</commandReference>";
-            xml += "\r\n<orderReference>" + orderReference + "</orderReference>";
-
-            return xml;
-        }
-    }
-     
     public class XmlUtil
     {
         public static string toXsdDate(DateTime dateTime)

--- a/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
+++ b/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
@@ -618,6 +618,7 @@ namespace Cnp.Sdk
             }
         }
 
+        public identityBundle identityBundle;
         public override string Serialize()
         {
             var xml = "\r\n<authorization";

--- a/CnpSdkForNet/CnpSdkForNet/XmlResponseFields.cs
+++ b/CnpSdkForNet/CnpSdkForNet/XmlResponseFields.cs
@@ -2187,6 +2187,10 @@ namespace Cnp.Sdk
         private string checkoutIdField;
         private string fundingTransactionReferenceNumberField;
 
+        //12.41 Two new elemnets-retrievalReferenceNumber and orderSouce
+        private string retrievalReferenceNumberField;
+        public orderSourceType orderSourceField;
+
         /// <remarks/>
         public long cnpTxnId
         {
@@ -2564,9 +2568,30 @@ namespace Cnp.Sdk
                 this.fundingTransactionReferenceNumberField = value;
             }
         }
-
+        public string retrievalReferenceNumber
+        {
+            get
+            {
+                return this.retrievalReferenceNumberField;
+            }
+            set
+            {
+                this.retrievalReferenceNumberField = value;
+            }
+        }
+        public orderSourceType orderSource
+        {
+            get
+            {
+                return this.orderSourceField;
+            }
+            set
+            {
+                this.orderSourceField = value;
+            }
+        }
     }
-    
+
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "2.0.50727.42")]
     [System.SerializableAttribute()]
@@ -4371,7 +4396,9 @@ namespace Cnp.Sdk
         private string checkoutIdField; //12.24
 
         private string fundingTransactionReferenceNumberField; //12.39
-
+        //12.41 Two new elemnets-retrievalReferenceNumber and orderSouce
+        private string retrievalReferenceNumberField;
+        public orderSourceType orderSourceField;
 
         /// <remarks/>
         public long cnpTxnId
@@ -4831,6 +4858,28 @@ namespace Cnp.Sdk
             set
             {
                 this.fundingTransactionReferenceNumberField = value;
+            }
+        }
+        public string retrievalReferenceNumber
+        {
+            get
+            {
+                return this.retrievalReferenceNumberField;
+            }
+            set
+            {
+                this.retrievalReferenceNumberField = value;
+            }
+        }
+        public orderSourceType orderSource
+        {
+            get
+            {
+                return this.orderSourceField;
+            }
+            set
+            {
+                this.orderSourceField = value;
             }
         }
     }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestAuth.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestAuth.cs
@@ -528,15 +528,15 @@ namespace Cnp.Sdk.Test.Functional
             var response = _cnp.Authorize(authorization);
             Assert.AreEqual("000", response.response);
 
-           /* // SANDBOX BRB
+            // SANDBOX BRB
             //Assert.AreEqual("63225578415568556365452427825", response.networkTransactionId);
             Assert.AreEqual("visa", response.enhancedAuthResponse.networkResponse.endpoint);
-            Assert.AreEqual(5, response.enhancedAuthResponse.networkResponse.networkField.fieldNumber);
-            Assert.AreEqual("Additional Request Data", response.enhancedAuthResponse.networkResponse.networkField.fieldName);
-            Assert.AreEqual("135798642", response.enhancedAuthResponse.networkResponse.networkField.fieldValue);*/
+            Assert.AreEqual(4, response.enhancedAuthResponse.networkResponse.networkField.fieldNumber);
+            Assert.AreEqual("Transaction Amount", response.enhancedAuthResponse.networkResponse.networkField.fieldName);
+            Assert.AreEqual("135798642", response.enhancedAuthResponse.networkResponse.networkField.fieldValue);
         }
 
-        [Test]
+            [Test]
         public void SimpleAuthWithCardPin()
         {
             var authorization = new authorization

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestAuth.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestAuth.cs
@@ -528,12 +528,12 @@ namespace Cnp.Sdk.Test.Functional
             var response = _cnp.Authorize(authorization);
             Assert.AreEqual("000", response.response);
 
-            // SANDBOX BRB
+           /* // SANDBOX BRB
             //Assert.AreEqual("63225578415568556365452427825", response.networkTransactionId);
             Assert.AreEqual("visa", response.enhancedAuthResponse.networkResponse.endpoint);
-            Assert.AreEqual(4, response.enhancedAuthResponse.networkResponse.networkField.fieldNumber);
-            Assert.AreEqual("Transaction Amount", response.enhancedAuthResponse.networkResponse.networkField.fieldName);
-            Assert.AreEqual("135798642", response.enhancedAuthResponse.networkResponse.networkField.fieldValue);
+            Assert.AreEqual(5, response.enhancedAuthResponse.networkResponse.networkField.fieldNumber);
+            Assert.AreEqual("Additional Request Data", response.enhancedAuthResponse.networkResponse.networkField.fieldName);
+            Assert.AreEqual("135798642", response.enhancedAuthResponse.networkResponse.networkField.fieldValue);*/
         }
 
         [Test]
@@ -1341,6 +1341,47 @@ namespace Cnp.Sdk.Test.Functional
             mylineItemData.subscription.Add(mysubscription);
             authorization.enhancedData.lineItems.Add(mylineItemData);
 
+            DateTime checkDate = new DateTime(0001, 1, 1, 00, 00, 00);
+
+            Assert.AreEqual("000", response.response);
+            Assert.AreEqual(checkDate, response.postDate);
+        }
+
+        //v12.41 New element identityBundle in authoriztion
+        //v12.43 originalRetrievalReferenceNumber, v12.44 'ecommerceDataOnly' value in order source enum
+        [Test]
+        public void SimpleAuthWithIdentityBundle()
+        {
+            var authorization = new authorization
+            {
+                id = "1",
+                reportGroup = "Planets",
+                orderId = "12344",
+                amount = 106,
+                orderSource = orderSourceType.ecommerceDataOnly,
+                card = new cardType
+                {
+                    type = methodOfPaymentTypeEnum.VI,
+                    number = "4100000000000000",
+                    expDate = "1210"
+                },
+                customBilling = new customBilling { phone = "1112223333" },
+                identityBundle = new identityBundle
+                {
+                    merchantId = "2222",
+                    entityId = "3333",
+                    entityReference = "3batchauthandcapture",
+                    resourceId = "12",
+                    resourceReference = "111111111111111",
+                    commandId = "111",
+                    commandReference = "12345",
+                    orderReference = "123"
+
+                },
+                originalRetrievalReferenceNumber="123456783"
+            };
+            var response = _cnp.Authorize(authorization);
+         
             DateTime checkDate = new DateTime(0001, 1, 1, 00, 00, 00);
 
             Assert.AreEqual("000", response.response);

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestAuthReversal.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestAuthReversal.cs
@@ -124,5 +124,34 @@ namespace Cnp.Sdk.Test.Functional
             var response = _cnp.AuthReversal(reversal);
             Assert.AreEqual("Approved", response.message);
         }
+
+        //v12.41 New element identityBundle in authReversal 
+        [Test]
+        public void SimpleAuthReversalWithIdentityBundle()
+        {
+            var reversal = new authReversal
+            {
+                id = "1",
+                reportGroup = "Planets",
+                cnpTxnId = 12345678000L,
+                amount = 106,
+                payPalNotes = "Notes",
+                 identityBundle = new identityBundle
+                 {
+                     merchantId = "2222",
+                     entityId = "3333",
+                     entityReference = "3batchauthandcapture",
+                     resourceId = "12",
+                     resourceReference = "111111111111111",
+                     commandId = "111",
+                     commandReference = "12345",
+                     orderReference = "123"
+
+                 }
+            };
+
+            var response = _cnp.AuthReversal(reversal);
+            Assert.AreEqual("Approved", response.message);
+        }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestBatch.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestBatch.cs
@@ -2522,6 +2522,193 @@ namespace Cnp.Sdk.Test.Functional
 
         } //12.33 End
 
+        // v12.41 New element identityBundle 
+        //v12.43 originalRetrievalReferenceNumber, v12.44 'ecommerceDataOnly' value in order source enum
+        [Test]
+        public void testBatchTxnv12_44()
+        {
+            var cnpBatchRequest = new batchRequest();
+            var card = new cardType();
+            card.type = methodOfPaymentTypeEnum.VI;
+            card.number = "4100000000000001";
+            card.expDate = "1210";
+
+            var identityBundle = new identityBundle
+            {
+                merchantId = "2222",
+                entityId = "3333",
+                entityReference = "3batchauthandcapture",
+                resourceId = "12",
+                resourceReference = "111111111111111",
+                commandId = "111",
+                commandReference = "12345",
+                orderReference = "123"
+            };
+
+            var authorization = new authorization
+            {
+                id = new Random().Next(100).ToString(),
+                reportGroup = "Planets",
+                orderId = "12344",
+                amount = 106,
+                orderSource = orderSourceType.ecommerceDataOnly,
+                crypto = false,
+                orderChannel = orderChannelEnum.PHONE,
+                fraudCheckStatus = "Not Approved",
+                card = card,
+                identityBundle = identityBundle,
+                originalRetrievalReferenceNumber = "123456"
+            };
+            cnpBatchRequest.addAuthorization(authorization);
+
+            var sale = new sale
+            {
+                amount = 106,
+                cnpTxnId = 123456,
+                orderId = "12344",
+                orderSource = orderSourceType.ecommerceDataOnly,
+                card = card,
+                identityBundle = identityBundle,
+                id = "id"
+            };
+            cnpBatchRequest.addSale(sale);
+
+            var capture = new capture
+            {
+                id = "1",
+                cnpTxnId = 123456000,
+                orderId = "defaultOrderId",
+                amount = 106,
+                partialCapture = new partialCapture
+                {
+                    partialCaptureSequenceNumber = 5,
+                    partialCaptureTotalCount = 5,
+                },
+                identityBundle = identityBundle,
+            };
+            cnpBatchRequest.addCapture(capture);
+
+            var credit = new credit
+            {
+                id = "10",
+                amount = 106,
+                orderId = "2111",
+                orderSource = orderSourceType.ecommerce,
+                card = card,
+                identityBundle = identityBundle
+            };
+            cnpBatchRequest.addCredit(credit);
+
+            var authReversal = new authReversal
+            {
+                cnpTxnId = 12345678000L,
+                amount = 106,
+                payPalNotes = "Notes",
+                id = "idAuthRev",
+                identityBundle = identityBundle
+            };
+            cnpBatchRequest.addAuthReversal(authReversal);
+
+            var depositTxnReversal = new depositTransactionReversal
+            {
+                id = "idDTR",
+                reportGroup = "Planets",
+                cnpTxnId = 12345678000L,
+                amount = 106,
+                identityBundle = identityBundle
+            };
+            cnpBatchRequest.addDepositTransactionReversal(depositTxnReversal);
+
+            var refundTxnReversal = new refundTransactionReversal
+            {
+                id = "idRTR",
+                reportGroup = "Planets",
+                cnpTxnId = 12345678000L,
+                amount = 106,
+                identityBundle = identityBundle
+            };
+            cnpBatchRequest.addRefundTransactionReversal(refundTxnReversal);
+
+            _cnp.addBatch(cnpBatchRequest);
+
+            var batchName = _cnp.sendToCnp();
+
+            _cnp.blockAndWaitForResponse(batchName, estimatedResponseTime(2 * 2, 10 * 2));
+
+            var cnpResponse = _cnp.receiveFromCnp(batchName);
+
+            Assert.NotNull(cnpResponse);
+            Assert.AreEqual("0", cnpResponse.response);
+            Assert.AreEqual("Valid Format", cnpResponse.message);
+
+            var cnpBatchResponse = cnpResponse.nextBatchResponse();
+
+            while (cnpBatchResponse != null)
+            {
+                var authResponse = cnpBatchResponse.nextAuthorizationResponse();
+                while (authResponse != null)
+                {
+                    Assert.AreEqual("000", authResponse.response);
+
+                    authResponse = cnpBatchResponse.nextAuthorizationResponse();
+                }
+                var saleResponse = cnpBatchResponse.nextSaleResponse();
+                while (saleResponse != null)
+                {
+                    Assert.AreEqual("000", saleResponse.response);
+
+                    saleResponse = cnpBatchResponse.nextSaleResponse();
+                }
+                var captureResponse = cnpBatchResponse.nextCaptureResponse();
+                while (captureResponse != null)
+                {
+                    Assert.AreEqual("000", captureResponse.response);
+
+                    captureResponse = cnpBatchResponse.nextCaptureResponse();
+                }
+
+                var creditResponse = cnpBatchResponse.nextCreditResponse();
+                while (creditResponse != null)
+                {
+                    Assert.AreEqual("000", creditResponse.response);
+
+                    creditResponse = cnpBatchResponse.nextCreditResponse();
+                }
+
+                var captureGivenAuthResponse = cnpBatchResponse.nextCaptureGivenAuthResponse();
+                while (captureGivenAuthResponse != null)
+                {
+                    Assert.AreEqual("000", captureGivenAuthResponse.response);
+
+                    captureGivenAuthResponse = cnpBatchResponse.nextCaptureGivenAuthResponse();
+                }
+                var authReversalResponse = cnpBatchResponse.nextAuthReversalResponse();
+                while (authReversalResponse != null)
+                {
+                    Assert.AreEqual("000", authReversalResponse.response);
+
+                    authReversalResponse = cnpBatchResponse.nextAuthReversalResponse();
+                }
+
+                var depositTxnReversalResponse = cnpBatchResponse.nextDepositTransactionReversalResponse();
+                while (depositTxnReversalResponse != null)
+                {
+                    Assert.AreEqual("000", depositTxnReversalResponse.response);
+
+                    depositTxnReversalResponse = cnpBatchResponse.nextDepositTransactionReversalResponse();
+                }
+
+                var reversalResponse = cnpBatchResponse.nextRefundTransactionReversalResponse();
+                while (reversalResponse != null)
+                {
+                    Assert.AreEqual("000", reversalResponse.response);
+
+                    reversalResponse = cnpBatchResponse.nextRefundTransactionReversalResponse();
+                }
+                cnpBatchResponse = cnpResponse.nextBatchResponse();
+            }
+        }
+
         private int estimatedResponseTime(int numAuthsAndSales, int numRest)
         {
             return (int)(5 * 60 * 1000 + 2.5 * 1000 + numAuthsAndSales * (1 / 5) * 1000 + numRest * (1 / 50) * 1000) * 5;

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestCapture.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestCapture.cs
@@ -337,5 +337,31 @@ namespace Cnp.Sdk.Test.Functional
             var response = _cnp.Capture(capture);
             Assert.AreEqual("Approved", response.message);
         }
+
+        //v12.41 New element identityBundle in capture 
+        [Test]
+        public void SimpleCaptureWithIdentityBundle()
+        {
+            var capture = new capture
+            {
+                id = "1",
+                cnpTxnId = 123456000,
+                amount = 106,                
+                identityBundle = new identityBundle
+                {
+                    merchantId = "2222",
+                    entityId = "3333",
+                    entityReference = "3batchauthandcapture",
+                    resourceId = "12",
+                    resourceReference = "111111111111111",
+                    commandId = "111",
+                    commandReference = "12345",
+                    orderReference = "123"
+                }
+            };
+          
+            var response = _cnp.Capture(capture);
+            Assert.AreEqual("Approved", response.message);
+        }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestCredit.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestCredit.cs
@@ -508,5 +508,39 @@ namespace Cnp.Sdk.Test.Functional
             var response = _cnp.Credit(creditObj);
             Assert.AreEqual("Approved", response.message);
         }
+
+        //v12.41 New element identityBundle in credit 
+        [Test]
+        public void SimpleCreditWithIdentityBundle()
+        {
+            var creditObj = new credit
+            {
+                id = "1",
+                reportGroup = "planets",
+                amount = 106,
+                orderId = "123OderId",
+                orderSource = orderSourceType.ecommerce,
+                card = new cardType
+                {
+                    type = methodOfPaymentTypeEnum.VI,
+                    number = "4100000<>0000001",
+                    expDate = "1210"
+                },
+                identityBundle = new identityBundle
+                {
+                    merchantId = "2222",
+                    entityId = "3333",
+                    entityReference = "3batchauthandcapture",
+                    resourceId = "12",
+                    resourceReference = "111111111111111",
+                    commandId = "111",
+                    commandReference = "12345",
+                    orderReference = "123"
+                }
+            };
+
+            var response = _cnp.Credit(creditObj);
+            Assert.AreEqual("Approved", response.message);
+        }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestDepositTransactionReversal.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestDepositTransactionReversal.cs
@@ -194,5 +194,33 @@ namespace Cnp.Sdk.Test.Functional
             Assert.AreEqual("Approved", response.message);
 
         }
+
+        //v12.41 New element identityBundle in DTR 
+        [Test]
+        public void TestTransactionReversalWithIdentityBundle()
+        {
+            var reversal = new depositTransactionReversal()
+            {
+                id = "1",
+                reportGroup = "Planets",
+                cnpTxnId = 12345678000L,
+                amount = 106,
+                customerId = "<'&\">",
+                identityBundle = new identityBundle
+                {
+                    merchantId = "2222",
+                    entityId = "3333",
+                    entityReference = "3batchauthandcapture",
+                    resourceId = "12",
+                    resourceReference = "111111111111111",
+                    commandId = "111",
+                    commandReference = "12345",
+                    orderReference = "123"
+                }
+            };
+
+            var response = _cnp.DepositTransactionReversal(reversal);
+            Assert.AreEqual("Approved", response.message);
+        }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestRealtimeIncrementalAuth.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestRealtimeIncrementalAuth.cs
@@ -36,10 +36,10 @@ namespace Cnp.Sdk.Test.Functional
                     expDate = "1210"
                 },
                 customBilling = new customBilling { phone = "1112223333" },
-                originalNetworkTransactionId= "1234",
-                originalRetrievalReferenceNumber="12345",
-                 cumulativeAmount=500,
-                 originalTransactionAmount=480
+                originalNetworkTransactionId = "1234",
+                originalRetrievalReferenceNumber = "12345",
+                cumulativeAmount = 500,
+                originalTransactionAmount = 480
             };
             var response = _cnp.realtimeIncrementalAuth(realtimeIncAuth);
 

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestRealtimeIncrementalAuth.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestRealtimeIncrementalAuth.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using System.Threading;
+
+namespace Cnp.Sdk.Test.Functional
+{
+    [TestFixture]
+    internal class TestRealtimeIncrementalAuth
+    {
+        private CnpOnline _cnp;
+        private Dictionary<string, string> _config;
+
+        [OneTimeSetUp]
+        public void SetUpCnp()
+        {
+            _config = new ConfigManager().getConfig();
+            _cnp = new CnpOnline(_config);
+        }
+
+        [Test]
+        public void realtimeIncrementalAuth()
+        {
+            var realtimeIncAuth = new realtimeIncrementalAuthorization
+            {
+                id = "1",
+                reportGroup = "Planets",
+                cnpTxnId = 12345,
+                orderId = "12344",
+                amount = 106,
+                orderSource = orderSourceType.ecommerce,
+                card = new cardType
+                {
+                    type = methodOfPaymentTypeEnum.VI,
+                    number = "414100000000000000",
+                    expDate = "1210"
+                },
+                customBilling = new customBilling { phone = "1112223333" },
+                originalNetworkTransactionId= "1234",
+                originalRetrievalReferenceNumber="12345",
+                 cumulativeAmount=500,
+                 originalTransactionAmount=480
+            };
+            var response = _cnp.realtimeIncrementalAuth(realtimeIncAuth);
+
+            DateTime checkDate = new DateTime(0001, 1, 1, 00, 00, 00);
+
+            Assert.AreEqual("000", response.response);
+            Assert.AreEqual(checkDate, response.postDate);
+        }
+    }
+}

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestRefundTransactionReversal.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestRefundTransactionReversal.cs
@@ -194,5 +194,33 @@ namespace Cnp.Sdk.Test.Functional
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual(12345678000L, response.recyclingResponse.creditCnpTxnId);
         }
+        
+        //v12.41 New element identityBundle in RTR 
+        [Test]
+        public void TestSimpleTransactionWithIdentityBundle()
+        {
+            var reversal = new refundTransactionReversal
+            {
+                id = "1",
+                reportGroup = "Planets",
+                cnpTxnId = 12345678000L,
+                amount = 106,
+                identityBundle = new identityBundle
+                {
+                    merchantId = "2222",
+                    entityId = "3333",
+                    entityReference = "3batchauthandcapture",
+                    resourceId = "12",
+                    resourceReference = "111111111111111",
+                    commandId = "111",
+                    commandReference = "12345",
+                    orderReference = "123"
+                }
+            };
+
+            var response = _cnp.RefundTransactionReversal(reversal);
+            Assert.AreEqual("sandbox", response.location);
+            Assert.AreEqual("Approved", response.message);
+        }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestSale.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestSale.cs
@@ -1023,5 +1023,39 @@ namespace Cnp.Sdk.Test.Functional
             var responseObj = _cnp.Sale(saleObj);
             StringAssert.AreEqualIgnoringCase("Approved", responseObj.message);
         }
+
+        //v12.41 New element identityBundle in sale, v12.44 'ecommerceDataOnly' value in order source enum 
+        [Test]
+        public void SimpleSaleWithidentityBundle()
+        {
+            var saleObj = new sale
+            {
+                amount = 106,
+                cnpTxnId = 123456,
+                id = "1",
+                orderId = "12344",
+                orderSource = orderSourceType.ecommerceDataOnly,
+                card = new cardType
+                {
+                    type = methodOfPaymentTypeEnum.VI,
+                    number = "4100000000000000",
+                    expDate = "1210"
+                },
+                identityBundle = new identityBundle
+                {
+                    merchantId = "2222",
+                    entityId = "3333",
+                    entityReference = "3batchauthandcapture",
+                    resourceId = "12",
+                    resourceReference = "111111111111111",
+                    commandId = "111",
+                    commandReference = "12345",
+                    orderReference = "123"
+                }
+            };
+
+            var responseObj = _cnp.Sale(saleObj);
+            StringAssert.AreEqualIgnoringCase("Approved", responseObj.message);
+        }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestAuthReversal.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestAuthReversal.cs
@@ -138,5 +138,49 @@ namespace Cnp.Sdk.Test.Unit
             Assert.AreEqual("sandbox", response.location);
         }
 
+        //v12.41 New element identityBundle in authReversal
+        [Test]
+        public void TestAuthReversalWithIdentityBundle()
+        {
+            authReversal reversal = new authReversal();
+            reversal.cnpTxnId = 3;
+            reversal.amount = 2;
+            reversal.surchargeAmount = 1;
+            reversal.payPalNotes = "note";
+            
+            var identityBundle = new identityBundle
+            {
+                merchantId = "2222",
+                entityId = "3333",
+                entityReference = "3batchauthandcapture",
+                resourceId = "12",
+                resourceReference = "111111111111111",
+                commandId = "111",
+                commandReference = "12345",
+                orderReference = "123"
+
+            };
+            reversal.identityBundle = identityBundle;
+
+            reversal.reportGroup = "Planets";
+            var mock = new Mock<Communications>();
+            if (config["encryptOltpPayload"] == "true")
+            {
+                mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<cnpOnlineRequest.*<encryptedPayload.*</encryptedPayload>.*", RegexOptions.Singleline)))
+                .Returns("<cnpOnlineResponse version='12.44' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><authReversalResponse><cnpTxnId>123</cnpTxnId><location>sandbox</location></authReversalResponse></cnpOnlineResponse>");
+            }
+            else
+            {
+                mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n<payPalNotes>note</payPalNotes>\r\n<identityBundle>.*", RegexOptions.Singleline)))
+                .Returns("<cnpOnlineResponse version='12.44' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><authReversalResponse><cnpTxnId>123</cnpTxnId><location>sandbox</location></authReversalResponse></cnpOnlineResponse>");
+            }
+            Communications mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            var response = cnp.AuthReversal(reversal);
+
+            Assert.NotNull(response);
+            Assert.AreEqual("sandbox", response.location);
+        }
+
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestAuthorization.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestAuthorization.cs
@@ -1413,5 +1413,56 @@ namespace Cnp.Sdk.Test.Unit
             Assert.NotNull(authorizationResponse);
             Assert.AreEqual(123, authorizationResponse.cnpTxnId);
         }
+
+        //v12.41 New element identityBundle in authoriztion
+        //v12.43 originalRetrievalReferenceNumber, v12.44 'ecommerceDataOnly' value in order source enum
+        [Test]
+        public void AuthWithIdentityBundle()
+        {
+            var auth = new authorization();
+            auth.orderId = "12344";
+            auth.amount = 2;
+            auth.orderSource = orderSourceType.ecommerceDataOnly;
+            var card = new cardType();
+            card.type = methodOfPaymentTypeEnum.MC;
+            card.number = "414100000000000000";
+            card.expDate = "1210";
+            card.pin = "1234";
+            auth.card = card;
+
+            var identityBundle = new identityBundle
+            {
+                merchantId = "2222",
+                entityId = "3333",
+                entityReference = "3batchauthandcapture",
+                resourceId = "12",
+                resourceReference = "111111111111111",
+                commandId = "111",
+                commandReference = "12345",
+                orderReference = "123"
+            };
+            auth.identityBundle = identityBundle;
+            auth.originalRetrievalReferenceNumber = "123456783123456";
+
+            auth.reportGroup = "Planets";
+
+            var mock = new Mock<Communications>();
+            if (config["encryptOltpPayload"] == "true")
+            {
+                mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<cnpOnlineRequest.*<encryptedPayload.*</encryptedPayload>.*", RegexOptions.Singleline)))
+                .Returns("<cnpOnlineResponse version=12.44' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><authorizationResponse><cnpTxnId>123</cnpTxnId></authorizationResponse></cnpOnlineResponse>");
+            }
+            else
+            {
+                mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<orderSource>ecommerceDataOnly</orderSource>.*", RegexOptions.Singleline)))
+                .Returns("<cnpOnlineResponse version='12.44' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><authorizationResponse><cnpTxnId>123</cnpTxnId></authorizationResponse></cnpOnlineResponse>");
+            }
+            var mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            var authorizationResponse = cnp.Authorize(auth);
+
+            Assert.NotNull(authorizationResponse);
+            Assert.AreEqual(123, authorizationResponse.cnpTxnId);
+        }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestBatch.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestBatch.cs
@@ -173,6 +173,18 @@ namespace Cnp.Sdk.Test.Unit
                 accountFundingTransactionType = accountFundingTransactionTypeEnum.accountToAccount
             };
             authorization.fraudCheckAction = fraudCheckActionEnum.APPROVED_SKIP_FRAUD_CHECK;
+            authorization.identityBundle = new identityBundle()
+            {
+                merchantId = "2222",
+                entityId = "3333",
+                entityReference = "3batchauthandcapture",
+                resourceId = "12",
+                resourceReference = "111111111111111",
+                commandId = "111",
+                commandReference = "12345",
+                orderReference = "123"
+            };
+            authorization.originalRetrievalReferenceNumber = "123456";
 
             var mockCnpResponse = new Mock<cnpResponse>();
             var mockCnpXmlSerializer = new Mock<cnpXmlSerializer>();
@@ -227,6 +239,17 @@ namespace Cnp.Sdk.Test.Unit
             authreversal.cnpTxnId = 12345678000;
             authreversal.amount = 106;
             authreversal.payPalNotes = "Notes";
+            authreversal.identityBundle = new identityBundle()
+            {
+                merchantId = "2222",
+                entityId = "3333",
+                entityReference = "3batchauthandcapture",
+                resourceId = "12",
+                resourceReference = "111111111111111",
+                commandId = "111",
+                commandReference = "12345",
+                orderReference = "123"
+            };
 
             var mockCnpResponse = new Mock<cnpResponse>();
             var mockCnpXmlSerializer = new Mock<cnpXmlSerializer>();
@@ -283,6 +306,17 @@ namespace Cnp.Sdk.Test.Unit
             capture capture = new capture();
             capture.cnpTxnId = 12345678000;
             capture.amount = 106;
+            capture.identityBundle = new identityBundle()
+            {
+                merchantId = "2222",
+                entityId = "3333",
+                entityReference = "3batchauthandcapture",
+                resourceId = "12",
+                resourceReference = "111111111111111",
+                commandId = "111",
+                commandReference = "12345",
+                orderReference = "123"
+            };
 
             var mockCnpResponse = new Mock<cnpResponse>();
             var mockCnpXmlSerializer = new Mock<cnpXmlSerializer>();
@@ -429,7 +463,18 @@ namespace Cnp.Sdk.Test.Unit
                 receiverAccountNumber = "4141000",
                 accountFundingTransactionType = accountFundingTransactionTypeEnum.accountToAccount
             };
-        
+            credit.identityBundle = new identityBundle()
+            {
+                merchantId = "2222",
+                entityId = "3333",
+                entityReference = "3batchauthandcapture",
+                resourceId = "12",
+                resourceReference = "111111111111111",
+                commandId = "111",
+                commandReference = "12345",
+                orderReference = "123"
+            };
+
             var mockCnpResponse = new Mock<cnpResponse>();
             var mockCnpXmlSerializer = new Mock<cnpXmlSerializer>();
 
@@ -817,6 +862,17 @@ namespace Cnp.Sdk.Test.Unit
                 accountFundingTransactionType = accountFundingTransactionTypeEnum.accountToAccount
             };
             sale.fraudCheckAction = fraudCheckActionEnum.APPROVED_SKIP_FRAUD_CHECK;
+            sale.identityBundle = new identityBundle()
+            {
+                merchantId = "2222",
+                entityId = "3333",
+                entityReference = "3batchauthandcapture",
+                resourceId = "12",
+                resourceReference = "111111111111111",
+                commandId = "111",
+                commandReference = "12345",
+                orderReference = "123"
+            };
 
             var mockCnpResponse = new Mock<cnpResponse>();
             var mockCnpXmlSerializer = new Mock<cnpXmlSerializer>();

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestCapture.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestCapture.cs
@@ -303,5 +303,48 @@ namespace Cnp.Sdk.Test.Unit
             Assert.AreEqual("sandbox", response.location);
         }
 
+        [Test]
+        public void TestCaptureWithIdentityBundle()///12.41
+        {
+            capture capture = new capture();
+            capture.cnpTxnId = 3;
+            capture.amount = 2;
+            capture.payPalNotes = "note";
+            capture.pin = "1234";
+
+            var identityBundle = new identityBundle
+            {
+                merchantId = "2222",
+                entityId = "3333",
+                entityReference = "3batchauthandcapture",
+                resourceId = "12",
+                resourceReference = "111111111111111",
+                commandId = "111",
+                commandReference = "12345",
+                orderReference = "123"
+
+            };
+            capture.identityBundle = identityBundle;
+
+            capture.reportGroup = "Planets";
+
+            var mock = new Mock<Communications>();
+            if (config["encryptOltpPayload"] == "true")
+            {
+                mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<cnpOnlineRequest.*<encryptedPayload.*</encryptedPayload>.*", RegexOptions.Singleline)))
+                .Returns("<cnpOnlineResponse version='12.44' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><captureResponse><cnpTxnId>123</cnpTxnId><location>sandbox</location></captureResponse></cnpOnlineResponse>");
+            }
+            else
+            {
+                mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<cnpTxnId>3</cnpTxnId>\r\n<amount>2</amount>.*<payPalNotes>.*<pin>.*<identityBundle>\r\n<merchantId>.*", RegexOptions.Singleline)))
+                .Returns("<cnpOnlineResponse version='12.44' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><captureResponse><cnpTxnId>123</cnpTxnId><location>sandbox</location></captureResponse></cnpOnlineResponse>");
+            }
+            Communications mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            var response = cnp.Capture(capture);
+
+            Assert.NotNull(response);
+            Assert.AreEqual("sandbox", response.location);
+        }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestCredit.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestCredit.cs
@@ -529,5 +529,48 @@ namespace Cnp.Sdk.Test.Unit
             cnp.SetCommunication(mockedCommunication);
             cnp.Credit(credit);
         }
+
+        [Test]
+        public void TestCreditWithIdentityBundle()
+        {
+            credit credit = new credit();
+            credit.orderId = "12344";
+            credit.amount = 2;
+            credit.orderSource = orderSourceType.ecommerce;
+            var identityBundle = new identityBundle
+            {
+                merchantId = "2222",
+                entityId = "3333",
+                entityReference = "3batchauthandcapture",
+                resourceId = "12",
+                resourceReference = "111111111111111",
+                commandId = "111",
+                commandReference = "12345",
+                orderReference = "123"
+
+            };
+            credit.identityBundle = identityBundle;
+
+            credit.reportGroup = "Planets";
+            
+
+            var mock = new Mock<Communications>();
+            if (config["encryptOltpPayload"] == "true")
+            {
+                mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<cnpOnlineRequest.*<encryptedPayload.*</encryptedPayload>.*", RegexOptions.Singleline)))
+                .Returns("<cnpOnlineResponse version='12.44' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><creditResponse><cnpTxnId>123</cnpTxnId><location>sandbox</location></creditResponse></cnpOnlineResponse>");
+            }
+            else
+            {
+                mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<identityBundle>\r\n<merchantId>.*", RegexOptions.Singleline)))
+                .Returns("<cnpOnlineResponse version='12.44' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><creditResponse><cnpTxnId>123</cnpTxnId><location>sandbox</location></creditResponse></cnpOnlineResponse>");
+            }
+            Communications mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            var response = cnp.Credit(credit);
+
+            Assert.NotNull(response);
+            Assert.AreEqual("sandbox", response.location);
+        }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestDepositTransactionReversal.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestDepositTransactionReversal.cs
@@ -215,5 +215,45 @@ namespace Cnp.Sdk.Test.Unit
             Assert.NotNull(response);
             Assert.AreEqual("sandbox", response.location);
         }
+
+        [Test]
+        public void TestTransactionReversalWithIdentityBundle()
+        {
+            depositTransactionReversal reversal = new depositTransactionReversal();
+            reversal.cnpTxnId = 3;
+            reversal.amount = 2;
+            var identityBundle = new identityBundle
+            {
+                merchantId = "2222",
+                entityId = "3333",
+                entityReference = "3batchauthandcapture",
+                resourceId = "12",
+                resourceReference = "111111111111111",
+                commandId = "111",
+                commandReference = "12345",
+                orderReference = "123"
+
+            };
+            reversal.identityBundle = identityBundle;
+            reversal.reportGroup = "Planets";
+
+            var mock = new Mock<Communications>();
+            if (config["encryptOltpPayload"] == "true")
+            {
+                mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<cnpOnlineRequest.*<encryptedPayload.*</encryptedPayload>.*", RegexOptions.Singleline)))
+                .Returns("<cnpOnlineResponse version='12.44' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><depositTransactionReversalResponse><cnpTxnId>123</cnpTxnId><location>sandbox</location></depositTransactionReversalResponse></cnpOnlineResponse>");
+            }
+            else
+            {
+                mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<identityBundle>\r\n<merchantId>2222</merchantId>.*", RegexOptions.Singleline)))
+                .Returns("<cnpOnlineResponse version='12.44' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><depositTransactionReversalResponse><cnpTxnId>123</cnpTxnId><location>sandbox</location></depositTransactionReversalResponse></cnpOnlineResponse>");
+            }
+            Communications mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            var response = cnp.DepositTransactionReversal(reversal);
+
+            Assert.NotNull(response);
+            Assert.AreEqual("sandbox", response.location);
+        }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestRefundTransactionReversal.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestRefundTransactionReversal.cs
@@ -215,5 +215,45 @@ namespace Cnp.Sdk.Test.Unit
             Assert.NotNull(response);
             Assert.AreEqual("sandbox", response.location);
         }
+
+        [Test]
+        public void TestTransactionReversalWithIdentityBundle()
+        {
+            refundTransactionReversal reversal = new refundTransactionReversal();
+            reversal.cnpTxnId = 3;
+            reversal.amount = 2;
+            var identityBundle = new identityBundle
+            {
+                merchantId = "2222",
+                entityId = "3333",
+                entityReference = "3batchauthandcapture",
+                resourceId = "12",
+                resourceReference = "111111111111111",
+                commandId = "111",
+                commandReference = "12345",
+                orderReference = "123"
+
+            };
+            reversal.identityBundle = identityBundle;
+            reversal.reportGroup = "Planets";
+
+            var mock = new Mock<Communications>();
+            if (config["encryptOltpPayload"] == "true")
+            {
+                mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<cnpOnlineRequest.*<encryptedPayload.*</encryptedPayload>.*", RegexOptions.Singleline)))
+                .Returns("<cnpOnlineResponse version='12.16' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><refundTransactionReversalResponse><cnpTxnId>123</cnpTxnId><location>sandbox</location></refundTransactionReversalResponse></cnpOnlineResponse>");
+            }
+            else
+            {
+                mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<identityBundle>\r\n<merchantId>2222</merchantId>.*", RegexOptions.Singleline)))
+                .Returns("<cnpOnlineResponse version='12.16' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><refundTransactionReversalResponse><cnpTxnId>123</cnpTxnId><location>sandbox</location></refundTransactionReversalResponse></cnpOnlineResponse>");
+            }
+            Communications mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            var response = cnp.RefundTransactionReversal(reversal);
+
+            Assert.NotNull(response);
+            Assert.AreEqual("sandbox", response.location);
+        }
     }
 }

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestSale.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestSale.cs
@@ -1079,7 +1079,7 @@ namespace Cnp.Sdk.Test.Unit
             };
             sale.identityBundle = identityBundle;
             sale.reportGroup = "Planets";
-           
+
 
             var mock = new Mock<Communications>();
             if (config["encryptOltpPayload"] == "true")

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestSale.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestSale.cs
@@ -10,7 +10,7 @@ namespace Cnp.Sdk.Test.Unit
     [TestFixture]
     class TestSale
     {
-        
+
         private CnpOnline cnp;
         Dictionary<String, String> config;
 
@@ -30,7 +30,7 @@ namespace Cnp.Sdk.Test.Unit
             sale.orderSource = orderSourceType.ecommerce;
             sale.reportGroup = "Planets";
             sale.fraudFilterOverride = false;
-           
+
             var mock = new Mock<Communications>();
             if (config["encryptOltpPayload"] == "true")
             {
@@ -130,7 +130,8 @@ namespace Cnp.Sdk.Test.Unit
         }
 
         [Test]
-        public void TestRecurringResponse_Full() {
+        public void TestRecurringResponse_Full()
+        {
             String xmlResponse = "<cnpOnlineResponse version='8.18' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><saleResponse><cnpTxnId>123</cnpTxnId><recurringResponse><subscriptionId>12</subscriptionId><responseCode>345</responseCode><responseMessage>Foo</responseMessage><recurringTxnId>678</recurringTxnId></recurringResponse></saleResponse></cnpOnlineResponse>";
             cnpOnlineResponse cnpOnlineResponse = CnpOnline.DeserializeObject(xmlResponse);
             saleResponse saleResponse = (saleResponse)cnpOnlineResponse.saleResponse;
@@ -153,7 +154,7 @@ namespace Cnp.Sdk.Test.Unit
             Assert.AreEqual(12, saleResponse.recurringResponse.subscriptionId);
             Assert.AreEqual("345", saleResponse.recurringResponse.responseCode);
             Assert.AreEqual("Foo", saleResponse.recurringResponse.responseMessage);
-            Assert.AreEqual(0,saleResponse.recurringResponse.recurringTxnId);
+            Assert.AreEqual(0, saleResponse.recurringResponse.recurringTxnId);
         }
 
         [Test]
@@ -458,7 +459,7 @@ namespace Cnp.Sdk.Test.Unit
             {
                 mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<ideal>\r\n<preferredLanguage>US</preferredLanguage>\r\n</ideal>.*", RegexOptions.Singleline)))
                 .Returns("<cnpOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><saleResponse><cnpTxnId>123</cnpTxnId></saleResponse></cnpOnlineResponse>");
-            } 
+            }
             Communications mockedCommunication = mock.Object;
             cnp.SetCommunication(mockedCommunication);
             cnp.Sale(sale);
@@ -546,7 +547,7 @@ namespace Cnp.Sdk.Test.Unit
             cnp.SetCommunication(mockedCommunication);
             cnp.Sale(sale);
         }
-        
+
         [Test]
         public void TestSaleWithLocation()
         {
@@ -556,7 +557,7 @@ namespace Cnp.Sdk.Test.Unit
             sale.orderSource = orderSourceType.ecommerce;
             sale.reportGroup = "Planets";
             sale.fraudFilterOverride = false;
-           
+
             var mock = new Mock<Communications>();
             if (config["encryptOltpPayload"] == "true")
             {
@@ -571,7 +572,7 @@ namespace Cnp.Sdk.Test.Unit
             Communications mockedCommunication = mock.Object;
             cnp.SetCommunication(mockedCommunication);
             var response = cnp.Sale(sale);
-            
+
             Assert.NotNull(response);
             Assert.AreEqual("sandbox", response.location);
         }
@@ -1011,7 +1012,7 @@ namespace Cnp.Sdk.Test.Unit
             sale.fraudCheckStatus = "Not Approved";
             enhancedData enhancedData = new enhancedData();
             enhancedData.lineItems = new List<lineItemData>();
-            
+
             var mysubscription = new subscriptions();
             mysubscription.subscriptionId = "123";
             mysubscription.currentPeriod = 112;
@@ -1031,7 +1032,7 @@ namespace Cnp.Sdk.Test.Unit
             mylineItemData.shipmentId = "2543";
             mylineItemData.subscription.Add(mysubscription);
             enhancedData.lineItems.Add(mylineItemData);
-            sale.enhancedData=enhancedData;
+            sale.enhancedData = enhancedData;
             sale.foreignRetailerIndicator = foreignRetailerIndicatorEnum.F;
 
             var mock = new Mock<Communications>();
@@ -1046,6 +1047,52 @@ namespace Cnp.Sdk.Test.Unit
                  .Returns("<cnpOnlineResponse version='12.33' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><saleResponse><cnpTxnId>123</cnpTxnId><location>sandbox</location></saleResponse></cnpOnlineResponse>");
             }
             var mockedCommunication = mock.Object;
+            cnp.SetCommunication(mockedCommunication);
+            var response = cnp.Sale(sale);
+
+            Assert.NotNull(response);
+            Assert.AreEqual("sandbox", response.location);
+        }
+
+        //v12.41 New element identityBundle in sale request , v12.44 'ecommerceDataOnly' value in order source enum
+        [Test]
+        public void TestSaleWithIdentityBundle()
+        {
+            sale sale = new sale();
+            sale.orderId = "12344";
+            sale.amount = 2;
+            sale.orderSource = orderSourceType.ecommerceDataOnly;
+            sale.reportGroup = "Planets";
+            sale.fraudFilterOverride = false;
+
+            var identityBundle = new identityBundle
+            {
+                merchantId = "2222",
+                entityId = "3333",
+                entityReference = "3batchauthandcapture",
+                resourceId = "12",
+                resourceReference = "111111111111111",
+                commandId = "111",
+                commandReference = "12345",
+                orderReference = "123"
+
+            };
+            sale.identityBundle = identityBundle;
+            sale.reportGroup = "Planets";
+           
+
+            var mock = new Mock<Communications>();
+            if (config["encryptOltpPayload"] == "true")
+            {
+                mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<cnpOnlineRequest.*<encryptedPayload.*</encryptedPayload>.*", RegexOptions.Singleline)))
+                .Returns("<cnpOnlineResponse version='12.44' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><saleResponse><cnpTxnId>123</cnpTxnId><location>sandbox</location></saleResponse></cnpOnlineResponse>");
+            }
+            else
+            {
+                mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<orderSource>ecommerceDataOnly</orderSource>.*", RegexOptions.Singleline)))
+                .Returns("<cnpOnlineResponse version='12.44' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><saleResponse><cnpTxnId>123</cnpTxnId><location>sandbox</location></saleResponse></cnpOnlineResponse>");
+            }
+            Communications mockedCommunication = mock.Object;
             cnp.SetCommunication(mockedCommunication);
             var response = cnp.Sale(sale);
 

--- a/CnpSdkForNet/CnpSdkForNetTest/app.config
+++ b/CnpSdkForNet/CnpSdkForNetTest/app.config
@@ -1,84 +1,84 @@
 <?xml version="1.0"?>
 <configuration>
-    <configSections>
-        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-            <section name="Cnp.Sdk.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false"/>
-        </sectionGroup>
-    </configSections>
-    <userSettings>
-        <Cnp.Sdk.Properties.Settings>
-            <setting name="reportGroup" serializeAs="String">
-                <value>Default Report Group</value>
-            </setting>
-            <setting name="onlineBatchUrl" serializeAs="String">
-                <value>payments.vantivprelive.com</value>
-            </setting>
-            <setting name="onlineBatchPort" serializeAs="String">
-                <value>15000</value>
-            </setting>
-            <setting name="requestDirectory" serializeAs="String">
-                <value>C:\Vantiv\</value>
-            </setting>
-            <setting name="responseDirectory" serializeAs="String">
-                <value>C:\Vantiv\</value>
-            </setting>
-            <setting name="logFile" serializeAs="String">
-                <value>true</value>
-            </setting>
-            <setting name="neuterAccountNums" serializeAs="String">
-                <value>true</value>
-            </setting>
-            <setting name="neuterUserCredentials=" serializeAs="String">
-                <value>true</value>
-            </setting>
-            <setting name="url" serializeAs="String">
-                <value>https://www.testvantivcnp.com/sandbox/communicator/online</value>				
+	<configSections>
+		<sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+			<section name="Cnp.Sdk.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false"/>
+		</sectionGroup>
+	</configSections>
+	<userSettings>
+		<Cnp.Sdk.Properties.Settings>
+			<setting name="reportGroup" serializeAs="String">
+				<value>Default Report Group</value>
 			</setting>
-            <setting name="proxyHost" serializeAs="String">
-                <value />
-            </setting>
-            <setting name="proxyPort" serializeAs="String">
-                <value />
-            </setting>
-            <setting name="username" serializeAs="String">
-                <value>SDKTEAM12</value>
-            </setting>
-            <setting name="password" serializeAs="String">
-				<value>V2b9F4k7</value>
-            </setting>
-            <setting name="keepAlive" serializeAs="String">
-                <value>true</value>
-            </setting>
-            <setting name="printxml" serializeAs="String">
-                <value>true</value>
-            </setting>
-            <setting name="timeout" serializeAs="String">
-                <value>6000</value>
-            </setting>
-            <setting name="merchantId" serializeAs="String">
-                <value>1288791</value>
-            </setting>
-            <setting name="sftpUrl" serializeAs="String">
-                <value>batch.vantivprelive.com</value>
-            </setting>
-            <setting name="sftpUsername" serializeAs="String">
-                <value>sdkv12txn</value>
-            </setting>
-            <setting name="sftpPassword" serializeAs="String">
-                <value>f4Vt2T4A</value>
-            </setting>
-            <setting name="useEncryption" serializeAs="String">
-                <value>false</value>
-            </setting>
-            <setting name="vantivPublicKeyId" serializeAs="String">
-                <value />
-            </setting>
-            <setting name="pgpPassphrase" serializeAs="String">
-                <value />
-            </setting>
-            <setting name="GnuPgDir" serializeAs="String">
-                <value />
-            </setting>
-        </Cnp.Sdk.Properties.Settings>
-    </userSettings>
+			<setting name="onlineBatchUrl" serializeAs="String">
+				<value>payments.vantivprelive.com</value>
+			</setting>
+			<setting name="onlineBatchPort" serializeAs="String">
+				<value>15000</value>
+			</setting>
+			<setting name="requestDirectory" serializeAs="String">
+				<value>C:\Vantiv\</value>
+			</setting>
+			<setting name="responseDirectory" serializeAs="String">
+				<value>C:\Vantiv\</value>
+			</setting>
+			<setting name="logFile" serializeAs="String">
+				<value>true</value>
+			</setting>
+			<setting name="neuterAccountNums" serializeAs="String">
+				<value>true</value>
+			</setting>
+			<setting name="neuterUserCredentials=" serializeAs="String">
+				<value>true</value>
+			</setting>
+			<setting name="url" serializeAs="String">
+				<value>https://www.testvantivcnp.com/sandbox/communicator/online</value>
+			</setting>
+			<setting name="proxyHost" serializeAs="String">
+				<value />
+			</setting>
+			<setting name="proxyPort" serializeAs="String">
+				<value />
+			</setting>
+			<setting name="username" serializeAs="String">
+				<value />
+			</setting>
+			<setting name="password" serializeAs="String">
+				<value />
+			</setting>
+			<setting name="keepAlive" serializeAs="String">
+				<value>true</value>
+			</setting>
+			<setting name="printxml" serializeAs="String">
+				<value>true</value>
+			</setting>
+			<setting name="timeout" serializeAs="String">
+				<value>5000</value>
+			</setting>
+			<setting name="merchantId" serializeAs="String">
+				<value>101</value>
+			</setting>
+			<setting name="sftpUrl" serializeAs="String">
+				<value>payments.vantivprelive.com</value>
+			</setting>
+			<setting name="sftpUsername" serializeAs="String">
+				<value>DOTNET</value>
+			</setting>
+			<setting name="sftpPassword" serializeAs="String">
+				<value>DOTNET</value>
+			</setting>
+			<setting name="useEncryption" serializeAs="String">
+				<value>false</value>
+			</setting>
+			<setting name="vantivPublicKeyId" serializeAs="String">
+				<value />
+			</setting>
+			<setting name="pgpPassphrase" serializeAs="String">
+				<value />
+			</setting>
+			<setting name="GnuPgDir" serializeAs="String">
+				<value />
+			</setting>
+		</Cnp.Sdk.Properties.Settings>
+	</userSettings>
 </configuration>

--- a/CnpSdkForNet/CnpSdkForNetTest/app.config
+++ b/CnpSdkForNet/CnpSdkForNetTest/app.config
@@ -32,8 +32,8 @@
                 <value>true</value>
             </setting>
             <setting name="url" serializeAs="String">
-                <value>https://www.testvantivcnp.com/sandbox/communicator/online</value>
-            </setting>
+                <value>https://www.testvantivcnp.com/sandbox/communicator/online</value>				
+			</setting>
             <setting name="proxyHost" serializeAs="String">
                 <value />
             </setting>
@@ -41,10 +41,10 @@
                 <value />
             </setting>
             <setting name="username" serializeAs="String">
-                <value />
+                <value>SDKTEAM12</value>
             </setting>
             <setting name="password" serializeAs="String">
-                <value />
+				<value>V2b9F4k7</value>
             </setting>
             <setting name="keepAlive" serializeAs="String">
                 <value>true</value>
@@ -53,19 +53,19 @@
                 <value>true</value>
             </setting>
             <setting name="timeout" serializeAs="String">
-                <value>5000</value>
+                <value>6000</value>
             </setting>
             <setting name="merchantId" serializeAs="String">
-                <value>101</value>
+                <value>1288791</value>
             </setting>
             <setting name="sftpUrl" serializeAs="String">
-                <value>payments.vantivprelive.com</value>
+                <value>batch.vantivprelive.com</value>
             </setting>
             <setting name="sftpUsername" serializeAs="String">
-                <value>DOTNET</value>
+                <value>sdkv12txn</value>
             </setting>
             <setting name="sftpPassword" serializeAs="String">
-                <value>DOTNET</value>
+                <value>f4Vt2T4A</value>
             </setting>
             <setting name="useEncryption" serializeAs="String">
                 <value>false</value>


### PR DESCRIPTION
==Change Log for 12.44 (March 19,2024)
          Change: [cnpAPI v12.44] In ordersourcetype enum, 'ecommerceDataOnly' value is added.

==Change Log for 12.43 [Only for Worldpay Internal Usage]
Change: [cnpAPI v12.43] Two new elements cumulativeAmount,originalTransactionAmount added in realtimeIncrementalAuthorization.
Change: [cnpAPI v12.43] In enum networkFieldNameEnumType,'Additional Request Data' value is added.

==Change Log for 12.42 [Only for Worldpay Internal Usage]
Change: [cnpAPI v12.42] For all child elements of identityBundle minOccurs changed to 0 from 1.
Change: [cnpAPI v12.42] New Transaction type realtimeIncrementalAuthorization added.
Change: [cnpAPI v12.42] New element originalRetrievalReferenceNumber added in authorization request.

==Change Log for 12.41
Change: [cnpAPI v12.41] In authorization,authReversal,capture,sale,credit,depositTransactionReversal,refundTransactionReversal new complex type element added - identityBundle.
Change: [cnpAPI v12.41] New complex type element identityBundle with child elements-merchantId,entityId,entityReference,resourceId,resourceReference,commandId,commandReference,orderReference with minOccurs as 1.
Change: [cnpAPI v12.41] New elements are added in authorizationResponse,saleResponse -retrievalReferenceNumber of type string12Type ,orderSource of type orderSourceType.
Change: [cnpAPI v12.41] New datatype- string12Type - of string type of length 12 to support retrievalReferenceNumber element .
Change: [cnpAPI v12.41] For existing element cardSuffixType maxLength is increased to 23