### PR TITLE
V12.45

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@
 
 
 ==Change Log for 12.46 (June 17,2025)
-* Change: [cnpAPI v12.46] In 'AuthorizationResponse' and 'SaleResponse' simple element 'credentialType' of tyape 'string' and 'cardDetails' of type 'ccAccountNumberType'.
+* Change: [cnpAPI v12.46] In 'AuthorizationResponse' and 'SaleResponse' simple element 'credentialType' of type 'string' and 'cardDetails' of type 'ccAccountNumberType'.
 * Change: [cnpAPI v12.46] In existing complex element 'accountFundingTransactionData' two simple elements 'receiverAccountNumber' of type 'string50Type' and 'receiverAccountNumberCnpToken' of type 'ccAccountNumberType' are added as choice.
 * Change: [cnpAPI v12.45] In existing enum 'foreignRetailerIndicatorEnum' new values 'A','B'.
 * Change: [cnpAPI v12.45] In existing authorization request new element 'foreignRetailerIndicator' of type 'foreignRetailerIndicatorEnum' is added.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,15 @@
 
 = Worldpay CNP CHANGELOG
 
+
+
+==Change Log for 12.46 (June 17,2025)
+* Change: [cnpAPI v12.46] In 'AuthorizationResponse' and 'SaleResponse' simple element 'credentialType' of tyape 'string' and 'cardDetails' of type 'ccAccountNumberType'.
+* Change: [cnpAPI v12.46] In existing complex element 'accountFundingTransactionData' two simple elements 'receiverAccountNumber' of type 'string50Type' and 'receiverAccountNumberCnpToken' of type 'ccAccountNumberType' are added as choice.
+* Change: [cnpAPI v12.45] In existing enum 'foreignRetailerIndicatorEnum' new values 'A','B'.
+* Change: [cnpAPI v12.45] In existing authorization request new element 'foreignRetailerIndicator' of type 'foreignRetailerIndicatorEnum' is added.
+* Change: [cnpAPI v12.45] In existing requests 'authorization','sale','captureGivenAuth' type of existing element 'typeOfDigitalCurrency' is changed from string to 'typeOfDigitalCurrencyEnum'.
+
 ==Change Log for 12.44 (March 19,2025)
 * Change: [cnpAPI v12.44] In ordersourcetype enum, 'ecommerceDataOnly' value is added.
  

--- a/CnpSdkForNet/CnpSdkForNet/CnpSdkForNet.csproj
+++ b/CnpSdkForNet/CnpSdkForNet/CnpSdkForNet.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>dotNetSDKKey.snk</AssemblyOriginatorKeyFile>
-        <PackageVersion>12.44.0</PackageVersion>
+        <PackageVersion>12.46.0</PackageVersion>
         <Title>Vantiv.CnpSdkForNet</Title>
         <Authors>FIS</Authors>
         <Copyright>Copyright © FIS 2020</Copyright>

--- a/CnpSdkForNet/CnpSdkForNet/CnpVersion.cs
+++ b/CnpSdkForNet/CnpSdkForNet/CnpVersion.cs
@@ -8,7 +8,7 @@ namespace Cnp.Sdk
      */
     public class CnpVersion
     {
-        public const String CurrentCNPXMLVersion = "12.44";
-        public const String CurrentCNPSDKVersion = "12.44.0";
+        public const String CurrentCNPXMLVersion = "12.46";
+        public const String CurrentCNPSDKVersion = "12.46.0";
     }
 }

--- a/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
+++ b/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
@@ -568,7 +568,22 @@ namespace Cnp.Sdk
                 authIndicatorSet = true;
             }
         }
-
+        //12.45 start
+        private foreignRetailerIndicatorEnum foreignRetailerIndicatorFeild;
+        private bool foreignRetailerIndicatorSet;
+        public foreignRetailerIndicatorEnum foreignRetailerIndicator
+        {
+            get
+            {
+                return foreignRetailerIndicatorFeild;
+            }
+            set
+            {
+                foreignRetailerIndicatorFeild = value;
+                foreignRetailerIndicatorSet = true;
+            }
+        }
+        //12.45 end
         //12.30 end
 
         public bool? skipRealtimeAU;
@@ -592,9 +607,9 @@ namespace Cnp.Sdk
             }
         }
 
-        private string typeOfDigitalCurrencyField;
+        private typeOfDigitalCurrencyEnum typeOfDigitalCurrencyField;
         private bool typeOfDigitalCurrencySet;
-        public string typeOfDigitalCurrency
+        public typeOfDigitalCurrencyEnum typeOfDigitalCurrency
         {
             get
             {
@@ -798,7 +813,13 @@ namespace Cnp.Sdk
                     xml += "\r\n<authIndicator>" + authIndicatorField + "</authIndicator>";
                 }
                 //end 
+                //12.45 start
 
+                if (foreignRetailerIndicatorSet)
+                {
+                    xml += "\r\n<foreignRetailerIndicator>" + foreignRetailerIndicatorFeild + "</foreignRetailerIndicator>";
+                }
+                //end 
                 if (merchantData != null)
                 {
                     xml += "\r\n<merchantData>" + merchantData.Serialize() + "\r\n</merchantData>";
@@ -858,7 +879,7 @@ namespace Cnp.Sdk
                 }
                 if (typeOfDigitalCurrencySet)
                 {
-                    xml += "\r\n<typeOfDigitalCurrency>" + typeOfDigitalCurrencyField + "</typeOfDigitalCurrency>";
+                    xml += "\r\n<typeOfDigitalCurrency>" + (int)typeOfDigitalCurrencyField + "</typeOfDigitalCurrency>";
                 }
                 if (conversionAffiliateIdSet)
                 {
@@ -1463,9 +1484,9 @@ namespace Cnp.Sdk
         }
         //12.31 end
         public accountFundingTransactionData accountFundingTransactionData;
-        private string typeOfDigitalCurrencyField;
+        private typeOfDigitalCurrencyEnum typeOfDigitalCurrencyField;
         private bool typeOfDigitalCurrencySet;
-        public string typeOfDigitalCurrency
+        public typeOfDigitalCurrencyEnum typeOfDigitalCurrency
         {
             get
             {
@@ -1619,7 +1640,7 @@ namespace Cnp.Sdk
             }
             if (typeOfDigitalCurrencySet)
             {
-                xml += "\r\n<typeOfDigitalCurrency>" + typeOfDigitalCurrencyField + "</typeOfDigitalCurrency>";
+                xml += "\r\n<typeOfDigitalCurrency>" + (int)typeOfDigitalCurrencyField + "</typeOfDigitalCurrency>";
             }
             if (conversionAffiliateIdSet)
             {
@@ -3162,9 +3183,9 @@ namespace Cnp.Sdk
             }
         }
 
-        private string typeOfDigitalCurrencyField;
+        private typeOfDigitalCurrencyEnum typeOfDigitalCurrencyField;
         private bool typeOfDigitalCurrencySet;
-        public string typeOfDigitalCurrency
+        public typeOfDigitalCurrencyEnum typeOfDigitalCurrency
         {
             get
             {
@@ -3433,7 +3454,7 @@ namespace Cnp.Sdk
 
             if (typeOfDigitalCurrencySet)
             {
-                xml += "\r\n<typeOfDigitalCurrency>" + typeOfDigitalCurrencyField + "</typeOfDigitalCurrency>";
+                xml += "\r\n<typeOfDigitalCurrency>" + (int)typeOfDigitalCurrencyField + "</typeOfDigitalCurrency>";
             }
             if (conversionAffiliateIdSet)
             {
@@ -4144,11 +4165,23 @@ namespace Cnp.Sdk
     }
     // 12.28, 12.29 and 12.30 end
 
-    //new 12.31 start
+    //new 12.45 start
     public enum foreignRetailerIndicatorEnum
     {
-        F
+        F,
+        A,
+        B
     }
+
+    public enum typeOfDigitalCurrencyEnum
+    {
+        One = 1,
+        Two=2,
+        Three=3,
+        Four=4,
+        Seven=7
+    }
+
     // 12.31 end
     #endregion
 
@@ -4195,6 +4228,7 @@ namespace Cnp.Sdk
         AFFIRM
     }
 
+ 
 
     #region Child elements.
     // The customerInfo element is the parent of several child elements use to define customer information.
@@ -7526,6 +7560,7 @@ namespace Cnp.Sdk
             }
         }
         public string receiverAccountNumber;
+        public string receiverAccountNumberCnpToken;
 
         public accountFundingTransactionTypeEnum accountFundingTransactionTypeFeild;
         public bool accountFundingTransactionTypeSet;
@@ -7560,6 +7595,7 @@ namespace Cnp.Sdk
                 xml += "\r\n<receiverAccountNumberType>" + receiverAccountNumberType + "</receiverAccountNumberType>";
             }
             if (receiverAccountNumber != null) xml += "\r\n<receiverAccountNumber>" + SecurityElement.Escape(receiverAccountNumber) + "</receiverAccountNumber>";
+            else if (receiverAccountNumberCnpToken != null) xml += "\r\n<receiverAccountNumberCnpToken>" + SecurityElement.Escape(receiverAccountNumberCnpToken) + "</receiverAccountNumberCnpToken>";
             if (accountFundingTransactionTypeSet)
             {
                 xml += "\r\n<accountFundingTransactionType>" + accountFundingTransactionType + "</accountFundingTransactionType>";

--- a/CnpSdkForNet/CnpSdkForNet/XmlResponseFields.cs
+++ b/CnpSdkForNet/CnpSdkForNet/XmlResponseFields.cs
@@ -2191,6 +2191,10 @@ namespace Cnp.Sdk
         private string retrievalReferenceNumberField;
         public orderSourceType orderSourceField;
 
+        //12.46 two new elements added
+
+        private string credentialTypeField;
+        private string cardDetailsField;
         /// <remarks/>
         public long cnpTxnId
         {
@@ -2526,6 +2530,25 @@ namespace Cnp.Sdk
                 this.networkTransactionIdField = value;
             }
         }
+
+        public string credentialType
+        {
+            get
+            {
+                return this.credentialTypeField;
+            }
+            set
+            {
+                this.credentialTypeField = value;
+            }
+        }
+
+        public string cardDetails
+        {
+            get { return this.cardDetailsField; }
+            set { this.cardDetailsField = value; }
+        }
+
 
         //TODO: make deserializable
         public string location
@@ -4400,6 +4423,10 @@ namespace Cnp.Sdk
         private string retrievalReferenceNumberField;
         public orderSourceType orderSourceField;
 
+        private string credentialTypeField;
+        private string cardDetailsField;
+
+
         /// <remarks/>
         public long cnpTxnId
         {
@@ -4831,6 +4858,25 @@ namespace Cnp.Sdk
                 this.authMaxField = value;
             }
         }
+
+        public string credentialType
+        {
+            get
+            {
+                return this.credentialTypeField;
+            }
+            set
+            {
+                this.credentialTypeField = value;
+            }
+        }
+
+        public string cardDetails
+        {
+            get { return this.cardDetailsField; }
+            set { this.cardDetailsField = value; }
+        }
+
         public string paymentAccountReferenceNumber
         {
             get { return paymentAccountReferenceNumberField; }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestAuth.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestAuth.cs
@@ -1306,6 +1306,7 @@ namespace Cnp.Sdk.Test.Functional
                     lineItems = new List<lineItemData>(),
 
                 },
+                foreignRetailerIndicator = foreignRetailerIndicatorEnum.A,
                 accountFundingTransactionData = new accountFundingTransactionData()
                 {
                     receiverFirstName = "abcc",
@@ -1313,11 +1314,11 @@ namespace Cnp.Sdk.Test.Functional
                     receiverCountry = countryTypeEnum.US,
                     receiverState = stateTypeEnum.AL,
                     receiverAccountNumberType = accountFundingTransactionAccountNumberTypeEnum.cardAccount,
-                    receiverAccountNumber = "4141000",
+                    receiverAccountNumberCnpToken = "41410004576986707",
                     accountFundingTransactionType = accountFundingTransactionTypeEnum.accountToAccount
                 },
                 fraudCheckAction = fraudCheckActionEnum.APPROVED_SKIP_FRAUD_CHECK,
-                typeOfDigitalCurrency = "abc",
+                typeOfDigitalCurrency = typeOfDigitalCurrencyEnum.Three,
                 conversionAffiliateId = "123",
             };
             var response = _cnp.Authorize(authorization);

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestBatch.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestBatch.cs
@@ -16,7 +16,7 @@ namespace Cnp.Sdk.Test.Functional
         [OneTimeSetUp]
         public void SetUp()
         {
-            EnvironmentVariableTestFlags.RequirePreliveBatchTestsEnabled();
+            /*EnvironmentVariableTestFlags.RequirePreliveBatchTestsEnabled();*/
             
             ConfigManager invalidConfigManager = new ConfigManager();
             _invalidConfig = invalidConfigManager.getConfig();
@@ -64,6 +64,7 @@ namespace Cnp.Sdk.Test.Functional
             };
             authorization.card = card;
             authorization.id = "id";
+            authorization.foreignRetailerIndicator = foreignRetailerIndicatorEnum.A;
             authorization.accountFundingTransactionData = new accountFundingTransactionData()
             {
                 receiverFirstName = "abcc",
@@ -99,7 +100,7 @@ namespace Cnp.Sdk.Test.Functional
             card2.expDate = "1210";
             authorization2.card = card2;
             authorization2.id = "id";
-            authorization2.typeOfDigitalCurrency = "type";
+            authorization2.typeOfDigitalCurrency = typeOfDigitalCurrencyEnum.One;
             authorization2.conversionAffiliateId = "conversion";
             cnpBatchRequest.addAuthorization(authorization2);
 
@@ -181,7 +182,7 @@ namespace Cnp.Sdk.Test.Functional
             capturegivenauth.orderSource = orderSourceType.ecommerce;
             capturegivenauth.card = card;
             capturegivenauth.id = "id";
-            capturegivenauth.typeOfDigitalCurrency = "type";
+            capturegivenauth.typeOfDigitalCurrency = typeOfDigitalCurrencyEnum.Three;
             capturegivenauth.conversionAffiliateId = "conversion";
             cnpBatchRequest.addCaptureGivenAuth(capturegivenauth);
 
@@ -395,7 +396,7 @@ namespace Cnp.Sdk.Test.Functional
             saleObj2.orderSource = orderSourceType.ecommerce;
             saleObj2.card = card2;
             saleObj2.id = "id";
-            saleObj2.typeOfDigitalCurrency = "Bcoin";
+            saleObj2.typeOfDigitalCurrency = typeOfDigitalCurrencyEnum.Four;
             saleObj2.conversionAffiliateId = "DC12345";
             cnpBatchRequest.addSale(saleObj2);
 
@@ -2018,7 +2019,7 @@ namespace Cnp.Sdk.Test.Functional
                 decisionPurpose = decisionPurposeEnum.INFORMATION_ONLY,
                 fraudSwitchIndicator = fraudSwitchIndicatorEnum.PRE,
                 customBilling = new customBilling { phone = "1112223333" },
-                authIndicator = authIndicatorEnum.Estimated
+                authIndicator = authIndicatorEnum.Estimated            
             };
 
             cnpBatchRequest.addAuthorization(authorization);
@@ -2290,6 +2291,7 @@ namespace Cnp.Sdk.Test.Functional
                     lineItems = new List<lineItemData>(),
                 },
                 customBilling = new customBilling { phone = "1112223333" },
+                foreignRetailerIndicator = foreignRetailerIndicatorEnum.A,
                 accountFundingTransactionData = new accountFundingTransactionData()
                 {
                     receiverFirstName = "abcc",

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestCaptureGivenAuth.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestCaptureGivenAuth.cs
@@ -309,7 +309,7 @@ namespace Cnp.Sdk.Test.Functional
                     receiverAccountNumber = "4141000",
 
                 },
-                typeOfDigitalCurrency = "asv",
+                typeOfDigitalCurrency = typeOfDigitalCurrencyEnum.Four,
                 conversionAffiliateId = "1",
             };
 

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestSale.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestSale.cs
@@ -997,7 +997,7 @@ namespace Cnp.Sdk.Test.Functional
                     accountFundingTransactionType = accountFundingTransactionTypeEnum.accountToAccount
                 },
                 fraudCheckAction = fraudCheckActionEnum.APPROVED_SKIP_FRAUD_CHECK,
-                typeOfDigitalCurrency = "abd",
+                typeOfDigitalCurrency = typeOfDigitalCurrencyEnum.Three,
                 conversionAffiliateId = "1",
             };
             var mysubscription = new subscriptions();

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestAuthorization.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestAuthorization.cs
@@ -429,6 +429,7 @@ namespace Cnp.Sdk.Test.Unit
                 receiverAccountNumberType = accountFundingTransactionAccountNumberTypeEnum.cardAccount,
                 receiverAccountNumber = "4141000",
                 accountFundingTransactionType = accountFundingTransactionTypeEnum.accountToAccount
+                auth.typeOfDigitalCurrency = typeOfDigitalCurrencyEnum.Three
             };
             auth.fraudCheckAction = fraudCheckActionEnum.APPROVED_SKIP_FRAUD_CHECK;
             var expectedResult = @"

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestAuthorization.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestAuthorization.cs
@@ -420,6 +420,7 @@ namespace Cnp.Sdk.Test.Unit
             checkType.authenticationProtocolVersion = "PAP";
             auth.cardholderAuthentication = checkType;
             auth.cardholderAuthentication.customerIpAddress = "192.168.1.1";
+            auth.foreignRetailerIndicator = foreignRetailerIndicatorEnum.A;
             auth.accountFundingTransactionData = new accountFundingTransactionData()
             {
                 receiverFirstName = "abcc",
@@ -427,10 +428,10 @@ namespace Cnp.Sdk.Test.Unit
                 receiverCountry = countryTypeEnum.US,
                 receiverState = stateTypeEnum.AL,
                 receiverAccountNumberType = accountFundingTransactionAccountNumberTypeEnum.cardAccount,
-                receiverAccountNumber = "4141000",
+                receiverAccountNumberCnpToken = "4141000",
                 accountFundingTransactionType = accountFundingTransactionTypeEnum.accountToAccount
-                auth.typeOfDigitalCurrency = typeOfDigitalCurrencyEnum.Three
             };
+            auth.typeOfDigitalCurrency = typeOfDigitalCurrencyEnum.Three;
             auth.fraudCheckAction = fraudCheckActionEnum.APPROVED_SKIP_FRAUD_CHECK;
             var expectedResult = @"
 <authorization id="""" reportGroup="""">
@@ -446,13 +447,14 @@ namespace Cnp.Sdk.Test.Unit
 <customerIpAddress>192.168.1.1</customerIpAddress>
 <authenticationProtocolVersion>PAP</authenticationProtocolVersion>
 </cardholderAuthentication>
+<foreignRetailerIndicator>A</foreignRetailerIndicator>
 <accountFundingTransactionData>
 <receiverFirstName>abcc</receiverFirstName>
 <receiverLastName>cde</receiverLastName>
 <receiverState>AL</receiverState>
 <receiverCountry>US</receiverCountry>
 <receiverAccountNumberType>cardAccount</receiverAccountNumberType>
-<receiverAccountNumber>4141000</receiverAccountNumber>
+<receiverAccountNumberCnpToken>4141000</receiverAccountNumberCnpToken>
 <accountFundingTransactionType>accountToAccount</accountFundingTransactionType>
 </accountFundingTransactionData>
 <fraudCheckAction>APPROVED_SKIP_FRAUD_CHECK</fraudCheckAction>

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestAuthorization.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestAuthorization.cs
@@ -1453,12 +1453,12 @@ namespace Cnp.Sdk.Test.Unit
             if (config["encryptOltpPayload"] == "true")
             {
                 mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<cnpOnlineRequest.*<encryptedPayload.*</encryptedPayload>.*", RegexOptions.Singleline)))
-                .Returns("<cnpOnlineResponse version=12.44' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><authorizationResponse><cnpTxnId>123</cnpTxnId></authorizationResponse></cnpOnlineResponse>");
+                .Returns("<cnpOnlineResponse version=12.46' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><authorizationResponse><cnpTxnId>123</cnpTxnId></authorizationResponse></cnpOnlineResponse>");
             }
             else
             {
                 mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<orderSource>ecommerceDataOnly</orderSource>.*", RegexOptions.Singleline)))
-                .Returns("<cnpOnlineResponse version='12.44' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><authorizationResponse><cnpTxnId>123</cnpTxnId></authorizationResponse></cnpOnlineResponse>");
+                .Returns("<cnpOnlineResponse version='12.46' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'><authorizationResponse><cnpTxnId>123</cnpTxnId></authorizationResponse></cnpOnlineResponse>");
             }
             var mockedCommunication = mock.Object;
             cnp.SetCommunication(mockedCommunication);

--- a/CnpSdkForNet/CnpSdkForNetTest/app.config
+++ b/CnpSdkForNet/CnpSdkForNetTest/app.config
@@ -41,10 +41,10 @@
 				<value />
 			</setting>
 			<setting name="username" serializeAs="String">
-				<value />
+				<value>SDKTEAM12</value>
 			</setting>
 			<setting name="password" serializeAs="String">
-				<value />
+				<value>V2b9F4k7</value>
 			</setting>
 			<setting name="keepAlive" serializeAs="String">
 				<value>true</value>
@@ -53,31 +53,40 @@
 				<value>true</value>
 			</setting>
 			<setting name="timeout" serializeAs="String">
-				<value>5000</value>
+				<value>6000</value>
 			</setting>
 			<setting name="merchantId" serializeAs="String">
-				<value>101</value>
+				<value>1288791</value>
 			</setting>
 			<setting name="sftpUrl" serializeAs="String">
-				<value>payments.vantivprelive.com</value>
+				<value>batch.vantivprelive.com</value>
 			</setting>
 			<setting name="sftpUsername" serializeAs="String">
-				<value>DOTNET</value>
+				<value>sdkv12txn</value>
 			</setting>
 			<setting name="sftpPassword" serializeAs="String">
-				<value>DOTNET</value>
+				<value>f4Vt2T4A</value>
 			</setting>
 			<setting name="useEncryption" serializeAs="String">
 				<value>false</value>
 			</setting>
 			<setting name="vantivPublicKeyId" serializeAs="String">
-				<value />
+				<value>94276408</value>
 			</setting>
 			<setting name="pgpPassphrase" serializeAs="String">
-				<value />
+				<value>sdksupport2018</value>
 			</setting>
 			<setting name="GnuPgDir" serializeAs="String">
-				<value />
+				<value>C:\Program Files (x86)\GnuPG\bin</value>
+			</setting>
+			<setting name="encryptOltpPayload" serializeAs="String">
+				<value>false</value>
+			</setting>
+			<setting name="oltpEncryptionKeySequence" serializeAs="String">
+				<value>10000</value>
+			</setting>
+			<setting name="oltpEncryptionKeyPath" serializeAs="String">
+				<value>C:\Users\e5651806\encryptionKey.asc</value>
 			</setting>
 		</Cnp.Sdk.Properties.Settings>
 	</userSettings>

--- a/CnpSdkForNet/CnpSdkForNetTest/app.config
+++ b/CnpSdkForNet/CnpSdkForNetTest/app.config
@@ -41,10 +41,10 @@
 				<value />
 			</setting>
 			<setting name="username" serializeAs="String">
-				<value>SDKTEAM12</value>
+				<value />
 			</setting>
 			<setting name="password" serializeAs="String">
-				<value>V2b9F4k7</value>
+				<value />
 			</setting>
 			<setting name="keepAlive" serializeAs="String">
 				<value>true</value>
@@ -53,40 +53,31 @@
 				<value>true</value>
 			</setting>
 			<setting name="timeout" serializeAs="String">
-				<value>6000</value>
+				<value>5000</value>
 			</setting>
 			<setting name="merchantId" serializeAs="String">
-				<value>1288791</value>
+				<value>101</value>
 			</setting>
 			<setting name="sftpUrl" serializeAs="String">
-				<value>batch.vantivprelive.com</value>
+				<value>payments.vantivprelive.com</value>
 			</setting>
 			<setting name="sftpUsername" serializeAs="String">
-				<value>sdkv12txn</value>
+				<value>DOTNET</value>
 			</setting>
 			<setting name="sftpPassword" serializeAs="String">
-				<value>f4Vt2T4A</value>
+				<value>DOTNET</value>
 			</setting>
 			<setting name="useEncryption" serializeAs="String">
 				<value>false</value>
 			</setting>
 			<setting name="vantivPublicKeyId" serializeAs="String">
-				<value>94276408</value>
+				<value />
 			</setting>
 			<setting name="pgpPassphrase" serializeAs="String">
-				<value>sdksupport2018</value>
+				<value />
 			</setting>
 			<setting name="GnuPgDir" serializeAs="String">
-				<value>C:\Program Files (x86)\GnuPG\bin</value>
-			</setting>
-			<setting name="encryptOltpPayload" serializeAs="String">
-				<value>false</value>
-			</setting>
-			<setting name="oltpEncryptionKeySequence" serializeAs="String">
-				<value>10000</value>
-			</setting>
-			<setting name="oltpEncryptionKeyPath" serializeAs="String">
-				<value>C:\Users\e5651806\encryptionKey.asc</value>
+				<value />
 			</setting>
 		</Cnp.Sdk.Properties.Settings>
 	</userSettings>


### PR DESCRIPTION
* Change: [cnpAPI v12.46] In 'AuthorizationResponse' and 'SaleResponse' simple element 'credentialType' of tyape 'string' and 'cardDetails' of type 'ccAccountNumberType'.
* Change: [cnpAPI v12.46] In existing complex element 'accountFundingTransactionData' two simple elements 'receiverAccountNumber' of type 'string50Type' and 'receiverAccountNumberCnpToken' of type 'ccAccountNumberType' are added as choice.
* Change: [cnpAPI v12.45] In existing enum 'foreignRetailerIndicatorEnum' new values 'A','B'.
* Change: [cnpAPI v12.45] In existing authorization request new element 'foreignRetailerIndicator' of type 'foreignRetailerIndicatorEnum' is added.
* Change: [cnpAPI v12.45] In existing requests 'authorization','sale','captureGivenAuth' type of existing element 'typeOfDigitalCurrency' is changed from string to 'typeOfDigitalCurrencyEnum'.