### PR TITLE
Version 12 49

### DIFF
--- a/CnpSdkForNet/CnpSdkForNet/CnpBatchRequest.cs
+++ b/CnpSdkForNet/CnpSdkForNet/CnpBatchRequest.cs
@@ -2223,7 +2223,7 @@ namespace Cnp.Sdk
         }
     }
 
-    public partial class reserveCredit : transactionTypeWithReportGroupAndRtp
+    public partial class reserveCredit : transactionTypeWithReportGroup
     {
 
         public string fundingSubmerchantId { get; set; }
@@ -2243,10 +2243,7 @@ namespace Cnp.Sdk
             if (customerId != null)
                 xml += "customerId=\"" + SecurityElement.Escape(customerId) + "\" ";
             xml += "reportGroup=\"" + SecurityElement.Escape(reportGroup) + "\" ";
-            if (rtpSet)
-            {
-                xml += " rtp=\"" + rtp.ToString().ToLower() + "\"";
-            }
+
             xml += ">";
             if (fundingSubmerchantId != null)
                 xml += "\r\n<fundingSubmerchantId>" + SecurityElement.Escape(fundingSubmerchantId) + "</fundingSubmerchantId>";

--- a/CnpSdkForNet/CnpSdkForNet/CnpSdkForNet.csproj
+++ b/CnpSdkForNet/CnpSdkForNet/CnpSdkForNet.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>dotNetSDKKey.snk</AssemblyOriginatorKeyFile>
-        <PackageVersion>12.48.0</PackageVersion>
+        <PackageVersion>12.49.0</PackageVersion>
         <Title>Vantiv.CnpSdkForNet</Title>
         <Authors>FIS</Authors>
         <Copyright>Copyright © FIS 2020</Copyright>

--- a/CnpSdkForNet/CnpSdkForNet/CnpVersion.cs
+++ b/CnpSdkForNet/CnpSdkForNet/CnpVersion.cs
@@ -8,7 +8,7 @@ namespace Cnp.Sdk
      */
     public class CnpVersion
     {
-        public const String CurrentCNPXMLVersion = "12.48";
-        public const String CurrentCNPSDKVersion = "12.48.0";
+        public const String CurrentCNPXMLVersion = "12.49";
+        public const String CurrentCNPSDKVersion = "12.49.0";
     }
 }

--- a/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
+++ b/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
@@ -2521,7 +2521,7 @@ namespace Cnp.Sdk
             if (customerIpAddress != null) xml += "\r\n<customerIpAddress>" + SecurityElement.Escape(customerIpAddress) + "</customerIpAddress>";
             if (authenticatedByMerchantSet) xml += "\r\n<authenticatedByMerchant>" + authenticatedByMerchantField + "</authenticatedByMerchant>";
             if (authenticationProtocolVersion != null) xml += "\r\n<authenticationProtocolVersion>" + authenticationProtocolVersion + "</authenticationProtocolVersion>";
-            if (tokenAuthenticationValue != null) xml += "\r\n<tokenAuthenticationValue>" + tokenAuthenticationValue + "</tokenAuthenticationValue";
+            if (tokenAuthenticationValue != null) xml += "\r\n<tokenAuthenticationValue>" + tokenAuthenticationValue + "</tokenAuthenticationValue>";
             return xml;
         }
     }

--- a/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
+++ b/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
@@ -657,6 +657,21 @@ namespace Cnp.Sdk
             }
         }
 
+        private bool preferredCustomerField;
+        private bool preferredCustomerSet;
+        public bool preferredCustomer
+        {
+            get
+            {
+                return preferredCustomerField;
+            }
+            set
+            {
+                preferredCustomerField = value;
+                preferredCustomerSet = true;
+            }
+        }
+
         public override string Serialize()
         {
             var xml = "\r\n<authorization";
@@ -3252,6 +3267,23 @@ namespace Cnp.Sdk
                 pazeEncryptedPayloadSet = true;
             }
         }
+
+        private bool preferredCustomerField;
+        private bool preferredCustomerSet;
+        public bool preferredCustomer
+        {
+            get
+            {
+                return preferredCustomerField;
+            }
+            set
+            {
+                preferredCustomerField = value;
+                preferredCustomerSet = true;
+            }
+        }
+
+
 
         public override string Serialize()
         {

--- a/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
+++ b/CnpSdkForNet/CnpSdkForNet/XmlRequestFields.cs
@@ -928,7 +928,9 @@ namespace Cnp.Sdk
                 if (originalRetrievalReferenceNumber != null) //12.42
                 {
                     xml += "\r\n<originalRetrievalReferenceNumber>" + originalRetrievalReferenceNumber + "</originalRetrievalReferenceNumber>";
-                }               
+                }
+                if (preferredCustomerSet) xml += "\r\n<preferredCustomer>" + preferredCustomer.ToString().ToLower() + "</preferredCustomer>";
+
             }
 
             xml += "\r\n</authorization>";
@@ -3537,7 +3539,9 @@ namespace Cnp.Sdk
             {
                 xml += "\r\n<identityBundle>" + identityBundle.Serialize() + "</identityBundle>";
             }
-            
+            if (preferredCustomerSet) xml += "\r\n<preferredCustomer>" + preferredCustomer.ToString().ToLower() + "</preferredCustomer>";
+
+
             //end
             //if (routingPreferenceSet)
             //{

--- a/CnpSdkForNet/CnpSdkForNet/XmlResponseFields.cs
+++ b/CnpSdkForNet/CnpSdkForNet/XmlResponseFields.cs
@@ -2953,6 +2953,7 @@ namespace Cnp.Sdk
     {
         One = 1,
         Two = 2,
+        Three = 3,
     }
    
    

--- a/CnpSdkForNet/CnpSdkForNet/XmlResponseFields.cs
+++ b/CnpSdkForNet/CnpSdkForNet/XmlResponseFields.cs
@@ -2197,6 +2197,8 @@ namespace Cnp.Sdk
         private string cardDetailsField;
 
         private tlid tlidField;
+        private bool preferredCustomerDecisionField;
+
 
         /// <remarks/>
         public long cnpTxnId
@@ -2625,6 +2627,19 @@ namespace Cnp.Sdk
             set
             {
                 this.tlidField = value;
+            }
+        }
+
+        public bool preferredCustomerDecision
+        {
+            get
+            {
+                return preferredCustomerDecisionField;
+            }
+            set
+            {
+                this.preferredCustomerDecisionField = value;
+               
             }
         }
     }
@@ -4537,6 +4552,8 @@ namespace Cnp.Sdk
 
         private string credentialTypeField;
         private string cardDetailsField;
+        private bool preferredCustomerDecisionField;
+        private tlid tlidField;
 
 
         /// <remarks/>
@@ -5038,6 +5055,30 @@ namespace Cnp.Sdk
             set
             {
                 this.orderSourceField = value;
+            }
+        }
+
+        public bool preferredCustomerDecision
+        {
+            get
+            {
+                return preferredCustomerDecisionField;
+            }
+            set
+            {
+                this.preferredCustomerDecisionField = value;
+
+            }
+        }
+        public tlid tlid
+        {
+            get
+            {
+                return this.tlidField;
+            }
+            set
+            {
+                this.tlidField = value;
             }
         }
     }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestAuth.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestAuth.cs
@@ -1425,12 +1425,35 @@ namespace Cnp.Sdk.Test.Functional
                 orderId = "12344",
                 amount = 106,
                 orderSource = orderSourceType.ecommerceDataOnly,
-                pazeEncryptedPayload = "NDEwMDAwMDAwMDAwMDAwMQ=="
+                pazeEncryptedPayload = "NDEwMDAwMDAwMDAwMDAwMQ==",
             };
+
             var response = _cnp.Authorize(authorization);
 
             DateTime checkDate = new DateTime(0001, 1, 1, 00, 00, 00);
                        
+            Assert.AreEqual(checkDate, response.postDate);
+            Assert.AreEqual("Generic Decline", response.message);
+        }
+
+        [Test]
+        public void SimpleAuthWithPreferredCustomer()
+        {
+            var authorization = new authorization
+            {
+                id = "1",
+                reportGroup = "Planets",
+                orderId = "12344",
+                amount = 106,
+                orderSource = orderSourceType.ecommerceDataOnly,
+                pazeEncryptedPayload = "NDEwMDAwMDAwMDAwMDAwMQ==",
+                preferredCustomer = false
+            };
+
+            var response = _cnp.Authorize(authorization);
+
+            DateTime checkDate = new DateTime(0001, 1, 1, 00, 00, 00);
+
             Assert.AreEqual(checkDate, response.postDate);
             Assert.AreEqual("Generic Decline", response.message);
         }

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestBatch.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestBatch.cs
@@ -16,7 +16,7 @@ namespace Cnp.Sdk.Test.Functional
         [OneTimeSetUp]
         public void SetUp()
         {
-            /*EnvironmentVariableTestFlags.RequirePreliveBatchTestsEnabled();*/
+         /*EnvironmentVariableTestFlags.RequirePreliveBatchTestsEnabled();*/
 
             ConfigManager invalidConfigManager = new ConfigManager();
             _invalidConfig = invalidConfigManager.getConfig();
@@ -2561,7 +2561,8 @@ namespace Cnp.Sdk.Test.Functional
                 fraudCheckStatus = "Not Approved",
                 card = card,
                 identityBundle = identityBundle,
-                originalRetrievalReferenceNumber = "123456"
+                originalRetrievalReferenceNumber = "123456",
+                preferredCustomer=true
             };
             cnpBatchRequest.addAuthorization(authorization);
 
@@ -2573,7 +2574,8 @@ namespace Cnp.Sdk.Test.Functional
                 orderSource = orderSourceType.ecommerceDataOnly,
                 card = card,
                 identityBundle = identityBundle,
-                id = "id"
+                id = "id",
+                preferredCustomer=false
             };
             cnpBatchRequest.addSale(sale);
 
@@ -2771,6 +2773,7 @@ namespace Cnp.Sdk.Test.Functional
                     commandReference = "12345",
                     orderReference = "123"
                 },
+
 
             };
             cnpBatchRequest.addSale(sale);

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestReserve.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestReserve.cs
@@ -23,7 +23,6 @@ namespace Cnp.Sdk.Test.Functional
                 // attributes.
                 id = "1",
                 reportGroup = "Default Report Group",
-                rtp = true,
                 // required child elements.
                 amount = 1512l,
                 fundingSubmerchantId = "value for fundingSubmerchantId",

--- a/CnpSdkForNet/CnpSdkForNetTest/Functional/TestSale.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Functional/TestSale.cs
@@ -1114,6 +1114,7 @@ namespace Cnp.Sdk.Test.Functional
                     commandReference = "12345",
                     orderReference = "123"
                 },
+                preferredCustomer = true
 
             };
 

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestAuthorization.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestAuthorization.cs
@@ -1447,6 +1447,7 @@ namespace Cnp.Sdk.Test.Unit
             };
             auth.identityBundle = identityBundle;
             auth.originalRetrievalReferenceNumber = "123456783123456";
+            auth.preferredCustomer = false;
 
             auth.reportGroup = "Planets";
 

--- a/CnpSdkForNet/CnpSdkForNetTest/Unit/TestSale.cs
+++ b/CnpSdkForNet/CnpSdkForNetTest/Unit/TestSale.cs
@@ -1078,6 +1078,7 @@ namespace Cnp.Sdk.Test.Unit
 
             };
             sale.identityBundle = identityBundle;
+            sale.preferredCustomer = true;
             sale.reportGroup = "Planets";
 
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Source Code available from : https://github.com/Vantiv/cnp-sdk-for-dotNet
 
 SDK can be tested in [sandbox environment](https://www.testvantivcnp.com/sandbox/communicator/online). Sandbox does not require valid credentials to begin testing. 
 
-Please contact [Vantiv eCommerce](http://developer.vantiv.com/community/ecommerce) to receive valid merchant credentials in order to run tests successfully or if you require assistance in any way.  We are reachable at sdksupport@fisglobal.com
+Please contact [Vantiv eCommerce](http://developer.vantiv.com/community/ecommerce) to receive valid merchant credentials in order to run tests successfully or if you require assistance in any way.  We are reachable at sdksupport@worldpay.com
 
 Setup
 -----
@@ -107,4 +107,4 @@ More examples can be found [Here](http://vantiv.github.io/dotnet/) or in [Functi
 
 Support
 -------
-Please contact Vantiv eCommerce with any further questions.   You can reach us at sdksupport@fisglobal.com.
+Please contact Vantiv eCommerce with any further questions.   You can reach us at sdksupport@worldpay.com.


### PR DESCRIPTION
- Change: [cnpAPI v12.49]: New simple element 'preferredCustomer' of type 'boolean' is added in  'authorization' and 'sale' request.
- Change: [cnpAPI v12.49]: New simple element 'preferredCustomerDecision' of type 'boolean' is added in Authorization and sale response.
- Change: [cnpAPI v12.49]: New complex element 'tlid' is added in sale response.
- Change: [cnpAPI v12.49]: In existing enum 'tlidValidationActionIndicatorType'  new value "3" is added.
- Change: [cnpAPI v12.49]: for existing request "reserveCredit" base type is changed from 'transactionTypeWithReportGroupAndRtp' to 'transactionTypeWithReportGroup'
